### PR TITLE
An 1871/add streamline model for historical cmc ohlc

### DIFF
--- a/macros/streamline/get_coin_gecko_prices/task_run_sp_bulk_get_coin_gecko_prices.sql
+++ b/macros/streamline/get_coin_gecko_prices/task_run_sp_bulk_get_coin_gecko_prices.sql
@@ -1,7 +1,7 @@
 {% macro task_run_sp_bulk_get_coin_gecko_prices(resume_or_suspend) -%}
     create or replace task silver.run_sp_bulk_get_coin_gecko_prices
         warehouse = dbt_cloud
-        schedule = 'USING CRON */2 * * * * UTC'
+        schedule = 'USING CRON 15,45 * * * * UTC'
     as
         call silver.sp_bulk_get_coin_gecko_prices();
 

--- a/models/streamline/streamline__coin_market_cap_historical_asset_ohlc_hourly.sql
+++ b/models/streamline/streamline__coin_market_cap_historical_asset_ohlc_hourly.sql
@@ -1,0 +1,62 @@
+{{ config(
+    materialized = 'view',
+) }}
+
+WITH base AS (
+
+    SELECT
+        id,
+        DATE_PART(
+            'epoch',
+            GREATEST(
+                VALUE :first_historical_data :: timestamp_ntz,
+                CURRENT_DATE - 365
+            )
+        ) AS historical_load_start_time,
+        DATE_PART(
+            'epoch',
+            LEAST(
+                VALUE :last_historical_data :: timestamp_ntz,
+                '2022-07-19 23:59:59.999' :: timestamp_ntz
+            )
+        ) AS historical_load_end_time
+    FROM
+        {{ source(
+            'crosschain_external',
+            'asset_metadata_api'
+        ) }}
+    WHERE
+        provider = 'coinmarketcap'
+        AND _inserted_date = (
+            SELECT
+                MAX(_inserted_date)
+            FROM
+                {{ source(
+                    'crosschain_external',
+                    'asset_metadata_api'
+                ) }}
+        )
+        AND VALUE :last_historical_data :: timestamp_ntz >= CURRENT_DATE - 365
+)
+SELECT
+    historical_load_start_time as start_time,
+    historical_load_end_time as end_time,
+    id AS asset_ids
+FROM
+    base
+WHERE 
+    end_time > start_time
+EXCEPT
+SELECT
+    api_start_time,
+    api_end_time,
+    id
+FROM
+    {{ source(
+        'crosschain_external',
+        'asset_ohlc_coin_market_cap_api'
+    ) }}
+WHERE
+    NULLIF(
+        DATA,{}
+    ) IS NOT NULL


### PR DESCRIPTION
- Add view to control historical loads for CoinMarketCap OHLC hourly prices
- Reduce frequency of CoinGecko tick prices calls due to rate limiting