### PR TITLE
An 1698/setup coingecko streamline ohlc views

### DIFF
--- a/models/sources.yml
+++ b/models/sources.yml
@@ -130,4 +130,49 @@ sources:
           - name: data
             data_type: variant
             description: ""
+      - name: asset_historical_hourly_market_data_coingecko_api
+        description: "all coins supported by provider"
+        external:
+          location: "@crosschain.bronze.analytics_external_tables/{{target.database}}/ASSET_HISTORICAL_HOURLY_MARKET_DATA_API/coingecko"
+          file_format: "( type = json, strip_outer_array = TRUE )"
+          auto_refresh: true
+          partitions:
+            - name: _inserted_date
+              data_type: string
+              expression: substr((split_part(METADATA$FILENAME,'/',4)),16,10)
+        columns:
+          - name: id
+            data_type: string
+            description: ""
+          - name: currency
+            data_type: string
+          - name: metadata
+            data_type: variant
+            description: ""
+          - name: data
+            data_type: variant
+            description: ""
+      - name: asset_ohlc_coingecko_api
+        description: "all coins supported by provider"
+        external:
+          location: "@crosschain.bronze.analytics_external_tables/{{target.database}}/ASSET_OHLC_API/coingecko"
+          file_format: "( type = json, strip_outer_array = TRUE )"
+          auto_refresh: true
+          partitions:
+            - name: _inserted_date
+              data_type: string
+              expression: substr((split_part(METADATA$FILENAME,'/',4)),16,10)
+        columns:
+          - name: id
+            data_type: string
+            description: ""
+          - name: run_time
+            data_type: timestamp_ntz
+          - name: metadata
+            data_type: string
+            description: ""
+          - name: data
+            data_type: variant
+            description: ""
+      
   

--- a/models/streamline/streamline__all_unknown_coin_gecko_asset_ohlc.sql
+++ b/models/streamline/streamline__all_unknown_coin_gecko_asset_ohlc.sql
@@ -1,0 +1,34 @@
+{{ config(
+    materialized = 'view',
+) }}
+
+SELECT
+    id,
+    date_trunc('hour',current_timestamp) AS run_time
+FROM
+    {{ source(
+        'crosschain_external',
+        'asset_metadata_api'
+    ) }}
+WHERE
+    provider = 'coingecko'
+    AND _inserted_date = (
+        SELECT
+            MAX(_inserted_date)
+        FROM
+            {{ source(
+                'crosschain_external',
+                'asset_metadata_api'
+            ) }}
+        WHERE
+            provider = 'coingecko'
+    )
+EXCEPT
+SELECT
+    id,
+    run_time
+FROM
+    {{ source(
+        'crosschain_external',
+        'asset_ohlc_coingecko_api'
+    ) }}

--- a/models/streamline/streamline__coin_gecko_historical_asset_market_data_hourly.sql
+++ b/models/streamline/streamline__coin_gecko_historical_asset_market_data_hourly.sql
@@ -1,0 +1,34 @@
+{{ config(
+    materialized = 'view',
+) }}
+
+SELECT
+    id,
+    90 AS days
+FROM
+    {{ source(
+        'crosschain_external',
+        'asset_metadata_api'
+    ) }}
+WHERE
+    provider = 'coingecko'
+    AND _inserted_date = (
+        SELECT
+            MAX(_inserted_date)
+        FROM
+            {{ source(
+                'crosschain_external',
+                'asset_metadata_api'
+            ) }}
+        WHERE
+            provider = 'coingecko'
+    )
+EXCEPT
+SELECT
+    id,
+    90
+FROM
+    {{ source(
+        'crosschain_external',
+        'asset_historical_hourly_market_data_coingecko_api'
+    ) }}


### PR DESCRIPTION
- Add streamline views for use when retrieving data from CoinGecko endpoints
- Add external bronze tables for data output from CoinGecko endpoints
- Currently these tables/views will not be in use in prod until we receive CoinGecko credentials but nothing should change on modeling side