### PR TITLE
add prices model for cmc

### DIFF
--- a/models/bronze/bronze__hourly_prices_coin_market_cap.sql
+++ b/models/bronze/bronze__hourly_prices_coin_market_cap.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized = 'view',
+) }}
+
+SELECT
+    *,
+    TO_TIMESTAMP_NTZ(SUBSTR(SPLIT_PART(metadata$filename, '/', 5), 1, 10) :: NUMBER, 0) AS _inserted_timestamp
+FROM
+    {{ source(
+        'crosschain_external',
+        'asset_ohlc_coin_market_cap_api'
+    ) }}

--- a/models/core/core__fact_hourly_prices.sql
+++ b/models/core/core__fact_hourly_prices.sql
@@ -14,3 +14,16 @@ SELECT
 FROM
     {{ ref('silver__hourly_prices_coin_gecko') }}
     p
+UNION
+SELECT
+    'coinmarketcap' AS provider,
+    p.id::string as id,
+    p.recorded_hour,
+    p.open,
+    p.high,
+    p.low,
+    p.close
+FROM
+    {{ ref('silver__hourly_prices_coin_market_cap') }}
+    p
+

--- a/models/core/core__fact_hourly_prices.yml
+++ b/models/core/core__fact_hourly_prices.yml
@@ -18,6 +18,10 @@ models:
         description: unique identifier representing the asset
         tests:
           - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
       - name: RECORDED_HOUR
         description: opening hour of price data
         tests:

--- a/models/silver/silver__hourly_prices_coin_market_cap.sql
+++ b/models/silver/silver__hourly_prices_coin_market_cap.sql
@@ -1,0 +1,52 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "CONCAT_WS('-', id, recorded_hour)",
+    incremental_strategy = 'delete+insert',
+    cluster_by = ['recorded_hour::DATE','_inserted_timestamp::DATE'],
+) }}
+
+WITH base AS (
+
+    SELECT
+        *
+    FROM
+        {{ ref('bronze__hourly_prices_coin_market_cap') }}
+
+{% if is_incremental() %}
+WHERE
+    _inserted_date >= (
+        SELECT
+            MAX(
+                _inserted_timestamp :: DATE
+            )
+        FROM
+            {{ this }}
+    )
+    AND _inserted_timestamp > (
+        SELECT
+            MAX(_inserted_timestamp)
+        FROM
+            {{ this }}
+    )
+{% else %}
+WHERE _inserted_date >= '2022-07-22'
+{% endif %}
+)
+SELECT
+    A.id,
+    DATE_TRUNC(
+        'hour',
+        f.value :quote :USD :timestamp :: timestamp_ntz
+    ) AS recorded_hour,
+    f.value :quote :USD :open::float AS OPEN,
+    f.value :quote :USD :high::float AS high,
+    f.value :quote :USD :low::float AS low,
+    f.value :quote :USD :close::float AS CLOSE,
+    f.value :quote :USD :volume::number AS volume,
+    f.value :quote :USD :market_cap::number AS market_cap,
+    A._inserted_timestamp
+FROM
+    base A,
+    TABLE(FLATTEN(DATA :quotes)) f qualify(ROW_NUMBER() over (PARTITION BY id, recorded_hour
+ORDER BY
+    _inserted_timestamp DESC)) = 1

--- a/models/silver/silver__hourly_prices_coin_market_cap.yml
+++ b/models/silver/silver__hourly_prices_coin_market_cap.yml
@@ -1,0 +1,60 @@
+version: 2
+models:
+  - name: silver__hourly_prices_coin_market_cap
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - ID
+            - RECORDED_HOUR
+    columns:
+      - name: ID
+        tests:
+          - not_null
+      - name: RECORDED_HOUR
+        tests:
+          - not_null
+      - name: OPEN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - FLOAT
+                - DOUBLE
+      - name: HIGH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - FLOAT
+                - DOUBLE
+      - name: LOW
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - FLOAT
+                - DOUBLE
+      - name: CLOSE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - FLOAT
+                - DOUBLE
+      - name: VOLUME
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
+      - name: MARKET_CAP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - INTEGER
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - not_null
+      


### PR DESCRIPTION
- Add silver houly prices model from coin market cap data
- Modify core table to include `provider=coinmarketcap`