### PR TITLE
initial create

### DIFF
--- a/models/core/core__dim_date_hours.sql
+++ b/models/core/core__dim_date_hours.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = "view",
+) }}
+
+
+WITH cte_my_date AS (
+    SELECT DATEADD(HOUR, SEQ4(), '2017-01-01 00:00:00') AS my_date
+    FROM TABLE(GENERATOR(ROWCOUNT=>1000000))
+)
+SELECT
+    TO_TIMESTAMP(my_date) as date_hour
+FROM cte_my_date
+WHERE date_hour < current_timestamp

--- a/models/core/core__dim_date_hours.yml
+++ b/models/core/core__dim_date_hours.yml
@@ -1,0 +1,7 @@
+version: 2
+models:
+  - name: core__dim_date_hours
+    description: Hold rows for each hour from 2017 to current timestamp (UTC)
+    columns:
+      - name: DATE_HOUR
+        description: Specific hour of a given date


### PR DESCRIPTION
- View that outputs a row for each hour from 2017 to the current timestamp.  Will continue to generate rows up till year 2130