### PR TITLE
fix/uniq-log-borrowing

### DIFF
--- a/models/defi/defi__ez_borrowing.yml
+++ b/models/defi/defi__ez_borrowing.yml
@@ -2,11 +2,7 @@ version: 2
 models:
   - name: defi__ez_borrowing
     description: 'This is a table that shows all the events across various blockchains and various platforms that are related to Borrowing or repaying the loan'
-
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - _LOG_ID
+    
     columns:
       - name: BLOCK_NUMBER
         description: '{{ doc("cross_chain_block_number") }}'


### PR DESCRIPTION
1. Removed a test that checks for unique values in `_log_id` column
2. This test already exists in the source repo and having it in crosschain results in duplicate errors / cumbersome troubleshooting