### PR TITLE
Add osmosis developer wallets labels

### DIFF
--- a/data/silver__osmosis_developer_vesting_receivers.csv
+++ b/data/silver__osmosis_developer_vesting_receivers.csv
@@ -1,0 +1,16 @@
+blockchain,creator,address,tag_name,tag_type,start_date,end_date
+osmosis,playwo,osmo14kjcwdwcqsujkdt8n5qwpd8x8ty2rys5rjrdjj,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo1gw445ta0aqn26suz2rg3tkqfpxnq2hs224d7gq,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo13lt0hzc6u3htsk7z5rs6vuurmgg4hh2ecgxqkf,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo1kvc3he93ygc0us3ycslwlv2gdqry4ta73vk9hu,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo19qgldlsk7hdv3ddtwwpvzff30pxqe9phq9evxf,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo19fs55cx4594een7qr8tglrjtt5h9jrxg458htd,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo1ssp6px3fs3kwreles3ft6c07mfvj89a544yj9k,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo1c5yu8498yzqte9cmfv5zcgtl07lhpjrj0skqdx,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo1yhj3r9t9vw7qgeg22cehfzj7enwgklw5k5v7lj,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo18nzmtyn5vy5y45dmcdnta8askldyvehx66lqgm,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo1z2x9z58cg96ujvhvu6ga07yv9edq2mvkxpgwmc,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo1tvf3373skua8e6480eyy38avv8mw3hnt8jcxg9,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo1zs0txy03pv5crj2rvty8wemd3zhrka2ne8u05n,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo1djgf9p53n7m5a55hcn6gg0cm5mue4r5g3fadee,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null
+osmosis,playwo,osmo1488zldkrn8xcjh3z40v2mexq7d088qkna8ceze,Developer Vesting Receiver,chadmin,2021-07-16 00:00:00.000,null

--- a/models/core/core__address_tags.sql
+++ b/models/core/core__address_tags.sql
@@ -299,6 +299,21 @@ SELECT
     address,
     tag_name,
     tag_type,
+    start_date :: date,
+    null as end_date,
+    '2022-12-13' :: TIMESTAMP AS tag_created_at
+FROM
+    {{ source(
+        'crosschain_silver',
+        'osmosis_developer_vesting_receivers'
+    ) }}
+UNION
+SELECT
+    blockchain,
+    creator,
+    address,
+    tag_name,
+    tag_type,
     start_date,
     end_date,
     tag_created_at


### PR DESCRIPTION
Those are the addresses receiving 25% of the network inflation on each epoch
https://www.mintscan.io/osmosis/parameters

Ideally this would include the percentage each of those includes but there is no field for custom data. Would it be ok putting that into the label name? 

For reference, those can be updated via governance but since the chain exists never have