### PR TITLE
Migrate to new streamline endpoints

### DIFF
--- a/macros/streamline/get_coin_gecko_asset_metadata/udf_bulk_get_coin_gecko_asset_metadata.sql
+++ b/macros/streamline/get_coin_gecko_asset_metadata/udf_bulk_get_coin_gecko_asset_metadata.sql
@@ -1,8 +1,8 @@
 {% macro udf_bulk_get_coin_gecko_asset_metadata() %}
     CREATE
     OR REPLACE EXTERNAL FUNCTION silver.udf_bulk_get_coin_gecko_asset_metadata() returns text api_integration = aws_crosschain_api_dev AS {% if target.database == "CROSSCHAIN" -%}
-        'https://q2il6n5mmg.execute-api.us-east-1.amazonaws.com/prod/bulk_get_coin_gecko_asset_metadata'
+        'https://35hm1qhag9.execute-api.us-east-1.amazonaws.com/prod/bulk_get_coin_gecko_asset_metadata'
     {% else %}
-        'https://ubuxgfotp2.execute-api.us-east-1.amazonaws.com/dev/bulk_get_coin_gecko_asset_metadata'
+        'https://tlbh2d47i2.execute-api.us-east-1.amazonaws.com/dev/bulk_get_coin_gecko_asset_metadata'
     {%- endif %}
 {% endmacro %}

--- a/macros/streamline/get_coin_gecko_ohlc/task_get_coin_gecko_ohlc.sql
+++ b/macros/streamline/get_coin_gecko_ohlc/task_get_coin_gecko_ohlc.sql
@@ -3,7 +3,7 @@
 execute immediate 'create or replace task streamline.bulk_get_coin_gecko_ohlc
     warehouse = dbt_cloud_crosschain
     allow_overlapping_execution = false
-    schedule = \'USING CRON 15,25,35,45 0 * * * UTC\'
+    schedule = \'USING CRON 15 0 * * * UTC\'
 as
 BEGIN
     call streamline.refresh_external_table_by_recent_date(\'asset_metadata_coin_gecko_api\');

--- a/macros/streamline/get_coin_gecko_ohlc/udf_bulk_get_coin_gecko_ohlc.sql
+++ b/macros/streamline/get_coin_gecko_ohlc/udf_bulk_get_coin_gecko_ohlc.sql
@@ -1,8 +1,8 @@
 {% macro udf_bulk_get_coin_gecko_ohlc() %}
     CREATE
     OR REPLACE EXTERNAL FUNCTION streamline.udf_bulk_get_coin_gecko_ohlc() returns text api_integration = aws_crosschain_api_dev AS {% if target.database == "CROSSCHAIN" -%}
-        'https://q2il6n5mmg.execute-api.us-east-1.amazonaws.com/prod/bulk_get_coin_gecko_ohlc'
+        'https://q2il6n5mmg.execute-api.us-east-1.amazonaws.com/prod/bulk_get_coin_gecko_hourly_ohlc'
     {% else %}
-        'https://ubuxgfotp2.execute-api.us-east-1.amazonaws.com/dev/bulk_get_coin_gecko_ohlc'
+        'https://tlbh2d47i2.execute-api.us-east-1.amazonaws.com/dev/bulk_get_coin_gecko_hourly_ohlc'
     {%- endif %}
 {% endmacro %}

--- a/macros/streamline/get_coin_gecko_ohlc/udf_bulk_get_coin_gecko_ohlc.sql
+++ b/macros/streamline/get_coin_gecko_ohlc/udf_bulk_get_coin_gecko_ohlc.sql
@@ -1,7 +1,7 @@
 {% macro udf_bulk_get_coin_gecko_ohlc() %}
     CREATE
     OR REPLACE EXTERNAL FUNCTION streamline.udf_bulk_get_coin_gecko_ohlc() returns text api_integration = aws_crosschain_api_dev AS {% if target.database == "CROSSCHAIN" -%}
-        'https://q2il6n5mmg.execute-api.us-east-1.amazonaws.com/prod/bulk_get_coin_gecko_hourly_ohlc'
+        'https://35hm1qhag9.execute-api.us-east-1.amazonaws.com/prod/bulk_get_coin_gecko_hourly_ohlc'
     {% else %}
         'https://tlbh2d47i2.execute-api.us-east-1.amazonaws.com/dev/bulk_get_coin_gecko_hourly_ohlc'
     {%- endif %}

--- a/macros/streamline/get_coin_market_cap_asset_metadata/udf_bulk_get_coin_market_cap_asset_metadata.sql
+++ b/macros/streamline/get_coin_market_cap_asset_metadata/udf_bulk_get_coin_market_cap_asset_metadata.sql
@@ -1,8 +1,8 @@
 {% macro udf_bulk_get_coin_market_cap_asset_metadata() %}
     CREATE
     OR REPLACE EXTERNAL FUNCTION silver.udf_bulk_get_coin_market_cap_asset_metadata() returns text api_integration = aws_crosschain_api_dev AS {% if target.database == "CROSSCHAIN" -%}
-        'https://q2il6n5mmg.execute-api.us-east-1.amazonaws.com/prod/bulk_get_coin_market_cap_asset_metadata'
+        'https://35hm1qhag9.execute-api.us-east-1.amazonaws.com/prod/bulk_get_coin_market_cap_asset_metadata'
     {% else %}
-        'https://ubuxgfotp2.execute-api.us-east-1.amazonaws.com/dev/bulk_get_coin_market_cap_asset_metadata'
+        'https://tlbh2d47i2.execute-api.us-east-1.amazonaws.com/dev/bulk_get_coin_market_cap_asset_metadata'
     {%- endif %}
 {% endmacro %}

--- a/macros/streamline/get_coin_market_cap_hourly_ohlc/udf_get_coin_market_cap_hourly_ohlc.sql
+++ b/macros/streamline/get_coin_market_cap_hourly_ohlc/udf_get_coin_market_cap_hourly_ohlc.sql
@@ -1,8 +1,8 @@
 {% macro udf_bulk_get_coin_market_cap_hourly_ohlc() %}
     CREATE
     OR REPLACE EXTERNAL FUNCTION streamline.udf_bulk_get_coin_market_cap_hourly_ohlc() returns text api_integration = aws_crosschain_api_dev AS {% if target.database == "CROSSCHAIN" -%}
-        'https://q2il6n5mmg.execute-api.us-east-1.amazonaws.com/prod/bulk_get_coin_market_cap_hourly_ohlc'
+        'https://35hm1qhag9.execute-api.us-east-1.amazonaws.com/prod/bulk_get_coin_market_cap_hourly_ohlc'
     {% else %}
-        'https://ubuxgfotp2.execute-api.us-east-1.amazonaws.com/dev/bulk_get_coin_market_cap_hourly_ohlc'
+        'https://tlbh2d47i2.execute-api.us-east-1.amazonaws.com/dev/bulk_get_coin_market_cap_hourly_ohlc'
     {%- endif %}
 {% endmacro %}


### PR DESCRIPTION
- Change endpoints to point to new streamline lambdas that use the streamline-core package
- Change frequency of coin gecko OHLC to once per day because it now utilizes SQS queue