### PR TITLE
fix/cg-cron-job

### DIFF
--- a/.github/workflows/dbt_run_streamline_coin_gecko_ohlc.yml
+++ b/.github/workflows/dbt_run_streamline_coin_gecko_ohlc.yml
@@ -4,7 +4,7 @@ run-name: dbt_run_streamline_coin_gecko_ohlc
 on:
   workflow_dispatch:
   schedule:
-    - cron: '15 0 * * *'
+    - cron: '15,45 * * * *'
     
 env:
   DBT_PROFILES_DIR: "${{ secrets.DBT_PROFILES_DIR }}"


### PR DESCRIPTION
Adjusted cron schedule for coingecko price feed from once per day to twice per hour to keep prices up to date