### PR TITLE
add solana to core dex swaps

### DIFF
--- a/models/core/core__ez_dex_swaps.sql
+++ b/models/core/core__ez_dex_swaps.sql
@@ -15,6 +15,7 @@ SELECT
     p_in.symbol AS symbol_in,
     dex.amount_in_raw,
     CASE
+        WHEN dex.blockchain = 'solana' THEN dex.amount_in_raw
         WHEN p_in.decimals IS NOT NULL THEN dex.amount_in_raw / power(
             10,
             p_in.decimals
@@ -28,6 +29,7 @@ SELECT
     p_out.symbol AS symbol_out,
     dex.amount_out_raw,
     CASE
+        WHEN dex.blockchain = 'solana' THEN dex.amount_out_raw
         WHEN p_out.decimals IS NOT NULL THEN dex.amount_out_raw / power(
             10,
             p_out.decimals

--- a/models/core/core__fact_dex_swaps.sql
+++ b/models/core/core__fact_dex_swaps.sql
@@ -99,6 +99,24 @@ WITH base AS (
             'osmosis_silver',
             'swaps'
         ) }}
+    UNION ALL
+    SELECT
+        'solana' AS blockchain,
+        swap_program as platform,
+        block_id as block_number,
+        block_timestamp,
+        tx_id as tx_hash,
+        swapper AS trader,
+        lower(swap_from_mint) as token_in,
+        swap_from_amount AS amount_in_raw,
+        lower(swap_to_mint) as token_out,
+        swap_to_amount AS amount_out_raw,
+        _log_id
+    from  {{ source(
+            'solana_core',
+            'fact_swaps'
+        ) }}
+    where succeeded
 )
 SELECT
     blockchain,


### PR DESCRIPTION
- add dex swaps from Solana blockchain
- swap amounts on Solana are already adjusted, so the adjusted and `raw` values will be the same