### PR TITLE
updated to daily invocation

### DIFF
--- a/.github/workflows/dbt_run_streamline_coin_gecko_market_chart_backfill.yml
+++ b/.github/workflows/dbt_run_streamline_coin_gecko_market_chart_backfill.yml
@@ -4,7 +4,7 @@ run-name: dbt_run_streamline_coin_gecko_market_chart_backfill
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/30 * * * *'
+      - cron: '0 1 * * *'  
     
 env:
   DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"

--- a/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
+++ b/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '5000', 'worker_batch_size', '5000', 'sql_limit', '30000'))",
+        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '5000', 'worker_batch_size', '5000', 'sql_limit', '1380000'))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_prices_history']


### PR DESCRIPTION
- Updates to invoke CG backfill once a day
- Updates CGMC backfill `sql_limit` to account for a 23 hour run to prevent `429`'s  in `OHLC` pipeline invocation

`OHLC` pipeline runtime:

![image](https://github.com/FlipsideCrypto/crosschain-models/assets/3241700/de7169b0-74ab-4d90-9a7d-e5c9e7ebcea1)
