### PR TITLE
add/prices-platform-name

### DIFF
--- a/models/silver/asset_metadata/silver__asset_metadata_all_providers.sql
+++ b/models/silver/asset_metadata/silver__asset_metadata_all_providers.sql
@@ -526,7 +526,10 @@ FINAL AS (
                 'arbitrum-one',
                 'arbitrum'
             ) THEN 'arbitrum'
-            WHEN platform IN ('avalanche') THEN 'avalanche'
+            WHEN platform IN (
+                'avalanche',
+                'avalanche c-chain'
+            ) THEN 'avalanche'
             WHEN platform IN (
                 'binance-smart-chain',
                 'binancecoin',
@@ -589,10 +592,10 @@ SELECT
         ['token_address','id','symbol','blockchain','provider']
     ) }} AS _unique_key,
     _inserted_timestamp,
-    sysdate() as inserted_timestamp,
-    sysdate() as modified_timestamp,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
     {{ dbt_utils.generate_surrogate_key(['token_address','id','symbol','blockchain','provider']) }} AS asset_metadata_all_providers_id,
-    '{{ invocation_id }}' as _invocation_id
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL
 WHERE

--- a/models/silver/hourly_prices/silver__token_prices_all_providers_hourly.sql
+++ b/models/silver/hourly_prices/silver__token_prices_all_providers_hourly.sql
@@ -81,7 +81,10 @@ FINAL AS (
                 'arbitrum-one',
                 'arbitrum'
             ) THEN 'arbitrum'
-            WHEN platform IN ('avalanche') THEN 'avalanche'
+            WHEN platform IN (
+                'avalanche',
+                'avalanchec-chain'
+            ) THEN 'avalanche'
             WHEN platform IN (
                 'binance-smart-chain',
                 'binancecoin',
@@ -135,10 +138,10 @@ SELECT
     is_imputed,
     _inserted_timestamp,
     _unique_key,
-    sysdate() as inserted_timestamp,
-    sysdate() as modified_timestamp,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
     {{ dbt_utils.generate_surrogate_key(['hour','token_address','blockchain','provider']) }} AS token_prices_all_providers_hourly_id,
-    '{{ invocation_id }}' as _invocation_id
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL --remove weird tokens / bad metadata
 WHERE


### PR DESCRIPTION
1. Adds `avalanche c-chain` platform naming
2. Requires FR in crosschain + avalanche

crosschain: `dbt run -m models/silver/asset_metadata/silver__asset_metadata_all_providers.sql+ models/silver/hourly_prices/silver__token_prices_all_providers_hourly.sql+ --full-refresh`

avalanche: `dbt run -m models/bronze/prices models/silver/prices --full-refresh`