### PR TITLE
add solana to bridge tables

### DIFF
--- a/models/docs/defi/bridge/bridge_activity.md
+++ b/models/docs/defi/bridge/bridge_activity.md
@@ -1,12 +1,12 @@
 {% docs bridge_ez_table_doc %}
 
-A comprehensive convenience table holding blockchain and platform specific bridge activity from event_logs, traces and transfers, including bridge deposits/withdrawals and transfers in/out on the following blockchains: Arbitrum, Avalanche, Base, BSC, Gnosis, Ethereum, Optimism and Polygon. This table also includes prices and token symbols, where available.
+A comprehensive convenience table holding blockchain and platform specific bridge activity from event_logs, traces and transfers, including bridge deposits/withdrawals and transfers in/out on the following blockchains: Arbitrum, Avalanche, Base, BSC, Gnosis, Ethereum, Optimism, Polygon and Solana. This table also includes prices and token symbols, where available.
 
 {% enddocs %}
 
 {% docs bridge_fact_table_doc %}
 
-A comprehensive convenience fact holding blockchain and platform specific bridge activity from event_logs, traces and transfers, including bridge deposits/withdrawals and transfers in/out on the following blockchains: Arbitrum, Avalanche, Base, BSC, Gnosis, Ethereum, Optimism and Polygon.
+A comprehensive fact table holding blockchain and platform specific bridge activity from event_logs, traces and transfers, including bridge deposits/withdrawals and transfers in/out on the following blockchains: Arbitrum, Avalanche, Base, BSC, Gnosis, Ethereum, Optimism, Polygon, and Solana.
 
 {% enddocs %}
 
@@ -66,7 +66,7 @@ The symbol representing the token being bridged. This provides a shorthand repre
 
 {% docs bridge_amount_unadj %}
 
-The raw, non-decimal adjusted amount of tokens involved in the bridge transaction.
+The raw, non-decimal adjusted amount of tokens involved in the bridge transaction. For Solana, these are decimal adjusted amounts.
 
 {% enddocs %}
 

--- a/models/gold/defi/defi__ez_bridge_activity.sql
+++ b/models/gold/defi/defi__ez_bridge_activity.sql
@@ -20,6 +20,7 @@ SELECT
     p.symbol AS token_symbol,
     b.amount_raw,
     CASE
+        WHEN b.blockchain = 'solana' then amount_raw
         WHEN p.decimals IS NOT NULL THEN b.amount_raw / power(
             10,
             p.decimals

--- a/models/gold/defi/defi__fact_bridge_activity.sql
+++ b/models/gold/defi/defi__fact_bridge_activity.sql
@@ -205,6 +205,43 @@ WITH base AS (
             'gnosis_defi',
             'ez_bridge_activity'
         ) }}
+    UNION ALL
+    SELECT
+        'solana' AS blockchain,
+        platform,
+        block_id AS block_number,
+        block_timestamp,
+        tx_id AS tx_hash,
+        CASE
+            WHEN direction = 'outbound' THEN 'solana'
+            ELSE NULL
+        END AS source_chain,
+        CASE
+            WHEN direction = 'inbound' THEN 'solana'
+            ELSE NULL
+        END AS destination_chain,
+        program_id AS bridge_address,
+        CASE
+            WHEN direction = 'outbound' THEN user_address
+            ELSE NULL
+        END AS source_address,
+        CASE
+            WHEN direction = 'inbound' THEN user_address
+            ELSE NULL
+        END AS destination_address,
+        direction,
+        lower(mint) AS token_address,
+        amount AS amount_raw,
+        COALESCE(inserted_timestamp,'2000-01-01') as inserted_timestamp,
+        COALESCE(modified_timestamp,'2000-01-01') as modified_timestamp,
+        {{ dbt_utils.generate_surrogate_key(
+            ['fact_bridge_activity_id','blockchain']
+        ) }} AS fact_bridge_activity_id
+    FROM
+        {{ source(
+            'solana_defi',
+            'fact_bridge_activity'
+        ) }}
 )
 SELECT
     blockchain,

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -237,6 +237,7 @@ sources:
     schema: defi
     tables:
       - name: fact_swaps
+      - name: fact_bridge_activity
   - name: near_core
     database: near
     schema: core


### PR DESCRIPTION
1. Add Solana bridge activity from solana.defi.fact_bridge_activity
2. Update docs

- Similar to swaps, amounts in Solana are already adjusted so the `raw_amount` and `amount_adj` will contain the same value
- The non-Solana chain information is not available within the on-chain data, so only the solana address (either `reciever` or `sender`) is populated. Likewise, the `destination_chain`/`source_chain` is null unless it is `solana`.