### PR TITLE
Stream 384 fan out backfill

### DIFF
--- a/.github/workflows/dbt_run_streamline_coin_gecko_market_chart_backfill.yml
+++ b/.github/workflows/dbt_run_streamline_coin_gecko_market_chart_backfill.yml
@@ -4,7 +4,7 @@ run-name: dbt_run_streamline_coin_gecko_market_chart_backfill
 on:
   workflow_dispatch:
   schedule:
-      - cron: '*/30 * * * *'  
+      - cron: '*/15 * * * *'  
     
 env:
   DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL := /bin/bash
 # set default target
 DBT_TARGET ?= dev
 AWS_LAMBDA_ROLE ?= aws_lambda_crosschain_api_dev
+INVOKE_STREAMS ?= True
 
 dbt-console: 
 	docker-compose run dbt_console
@@ -11,7 +12,7 @@ dbt-console:
 
 prices_history:
 	dbt run \
-	--vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_USE_DEV_FOR_EXTERNAL_TABLES": True}' \
+	--vars '{"STREAMLINE_INVOKE_STREAMS": $(INVOKE_STREAMS), "STREAMLINE_USE_DEV_FOR_EXTERNAL_TABLES": True}' \
 	-m "crosschain_models,tag:streamline_prices_complete" "crosschain_models,tag:streamline_prices_history" \
 	--profile crosschain \
 	--target $(DBT_TARGET) \

--- a/models/streamline/backfill/streamline__complete_coingecko_prices.sql
+++ b/models/streamline/backfill/streamline__complete_coingecko_prices.sql
@@ -32,6 +32,3 @@ WHERE
     )
 {% endif %}
  
-qualify(ROW_NUMBER() over (PARTITION BY uid
-ORDER BY
-    run_time DESC)) = 1

--- a/models/streamline/backfill/streamline__complete_coingecko_prices.sql
+++ b/models/streamline/backfill/streamline__complete_coingecko_prices.sql
@@ -31,4 +31,4 @@ WHERE
         '1900-01-01' :: timestamp_ntz
     )
 {% endif %}
- 
+

--- a/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
+++ b/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '460000', 'worker_batch_size', '25000', 'sql_limit', '840000'))",
+        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '640000', 'worker_batch_size', '25000', 'sql_limit', '1400000'))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_prices_history']

--- a/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
+++ b/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '640000', 'worker_batch_size', '25000', 'sql_limit', '1400000'))",
+        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '460000', 'worker_batch_size', '25000', 'sql_limit', '840000'))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_prices_history']

--- a/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
+++ b/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '225000', 'worker_batch_size', '25000', 'sql_limit', '640000'))",
+        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '225000', 'worker_batch_size', '25000', 'sql_limit', '840000'))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_prices_history']

--- a/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
+++ b/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '25000', 'worker_batch_size', '25000', 'sql_limit', '60000'))",
+        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '225000', 'worker_batch_size', '25000', 'sql_limit', '640000'))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_prices_history']

--- a/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
+++ b/models/streamline/backfill/streamline__get_coingecko_prices_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '225000', 'worker_batch_size', '25000', 'sql_limit', '840000'))",
+        func = "{{this.schema}}.udf_bulk_get_coin_gecko_prices(object_construct('sql_source', '{{this.identifier}}','external_table', 'ASSET_PRICES_API','producer_batch_size', '460000', 'worker_batch_size', '25000', 'sql_limit', '840000'))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_prices_history']


### PR DESCRIPTION
- Removes qualify clause from complete model
- Updated `get_coingecko_prices_history` with udf args to fan out to 9 worker lambas