### PR TITLE
fix/history-timing

### DIFF
--- a/.github/workflows/dbt_alter_gha_task.yml
+++ b/.github/workflows/dbt_alter_gha_task.yml
@@ -1,0 +1,46 @@
+name: dbt_alter_gha_task
+run-name: dbt_alter_gha_task
+
+on:
+  workflow_dispatch:
+    branches:
+      - "main"
+    inputs:
+      workflow_name:
+        type: string
+        description: Name of the workflow to perform the action on, no .yml extension
+        required: true
+      task_action:
+        type: choice 
+        description: Action to perform
+        required: true
+        options:
+          - SUSPEND
+          - RESUME
+        default: SUSPEND
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  called_workflow_template:
+    uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt_alter_gha_tasks.yml@main
+    with:
+      workflow_name: |
+         ${{ inputs.workflow_name }}
+      task_action: |
+         ${{ inputs.task_action }}
+      environment: workflow_prod
+    secrets: inherit

--- a/.github/workflows/dbt_run_streamline_asset_metadata.yml
+++ b/.github/workflows/dbt_run_streamline_asset_metadata.yml
@@ -3,9 +3,8 @@ run-name: dbt_run_streamline_asset_metadata
 
 on:
   workflow_dispatch:
-  schedule:
-      # Runs at minute 5 every hour (see https://crontab.guru)
-      - cron: '5 * * * *'  
+    branches:
+      - "main"
     
 env:
   DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"

--- a/.github/workflows/dbt_run_streamline_prices_history.yml
+++ b/.github/workflows/dbt_run_streamline_prices_history.yml
@@ -3,9 +3,8 @@ run-name: dbt_run_streamline_prices_history
 
 on:
   workflow_dispatch:
-  schedule:
-      # Runs every 4 hours (see https://crontab.guru)
-      - cron: '10 */4 * * *'  
+    branches:
+      - "main"
     
 env:
   DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"

--- a/.github/workflows/dbt_run_streamline_prices_realtime.yml
+++ b/.github/workflows/dbt_run_streamline_prices_realtime.yml
@@ -3,9 +3,8 @@ run-name: dbt_run_streamline_prices_realtime
 
 on:
   workflow_dispatch:
-  schedule:
-      # Runs at minute 25 every hour (see https://crontab.guru)
-      - cron: '25 * * * *'  
+    branches:
+      - "main"
     
 env:
   DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"

--- a/.github/workflows/dbt_test_tasks.yml
+++ b/.github/workflows/dbt_test_tasks.yml
@@ -1,0 +1,27 @@
+name: dbt_test_tasks
+run-name: dbt_test_tasks
+
+on:
+  workflow_dispatch:
+    branches:
+      - "main"
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  called_workflow_template:
+    uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt_test_tasks.yml@main
+    secrets: inherit

--- a/data/github_actions__workflows.csv
+++ b/data/github_actions__workflows.csv
@@ -1,0 +1,5 @@
+workflow_name,workflow_schedule
+dbt_run_streamline_prices_history,"45 * * * *"
+dbt_run_streamline_prices_realtime,"25 * * * *"
+dbt_run_streamline_asset_metadata,"5 * * * *"
+dbt_test_tasks,"15 * * * *"

--- a/data/github_actions__workflows.csv
+++ b/data/github_actions__workflows.csv
@@ -1,5 +1,5 @@
 workflow_name,workflow_schedule
-dbt_run_streamline_prices_history,"45 * * * *"
+dbt_run_streamline_prices_history,"45 * */1 * *"
 dbt_run_streamline_prices_realtime,"25 * * * *"
 dbt_run_streamline_asset_metadata,"5 * * * *"
 dbt_test_tasks,"15 * * * *"

--- a/models/silver/github_actions/github_actions__current_task_status.sql
+++ b/models/silver/github_actions/github_actions__current_task_status.sql
@@ -1,0 +1,6 @@
+{{ config(
+    materialized = 'view',
+    tags = ['gha_tasks']
+) }}
+
+{{ fsc_utils.gha_task_current_status_view() }}

--- a/models/silver/github_actions/github_actions__current_task_status.yml
+++ b/models/silver/github_actions/github_actions__current_task_status.yml
@@ -1,0 +1,16 @@
+version: 2
+models:
+  - name: github_actions__current_task_status
+    columns:
+      - name: PIPELINE_ACTIVE
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set:
+                - TRUE
+      - name: SUCCESSES
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set:
+                - 2
+              config: 
+                  severity: warn

--- a/models/silver/github_actions/github_actions__task_history.sql
+++ b/models/silver/github_actions/github_actions__task_history.sql
@@ -1,0 +1,5 @@
+{{ config(
+    materialized = 'view'
+) }}
+
+{{ fsc_utils.gha_task_history_view() }}

--- a/models/silver/github_actions/github_actions__task_performance.sql
+++ b/models/silver/github_actions/github_actions__task_performance.sql
@@ -1,0 +1,5 @@
+{{ config(
+    materialized = 'view'
+) }}
+
+{{ fsc_utils.gha_task_performance_view() }}

--- a/models/silver/github_actions/github_actions__task_schedule.sql
+++ b/models/silver/github_actions/github_actions__task_schedule.sql
@@ -1,0 +1,5 @@
+{{ config(
+    materialized = 'view'
+) }}
+
+{{ fsc_utils.gha_task_schedule_view() }}

--- a/models/silver/github_actions/github_actions__tasks.sql
+++ b/models/silver/github_actions/github_actions__tasks.sql
@@ -1,0 +1,5 @@
+{{ config(
+    materialized = 'view'
+) }}
+
+{{ fsc_utils.gha_tasks_view() }}

--- a/models/silver/hourly_prices/coin_gecko2/silver__all_prices_coingecko2.sql
+++ b/models/silver/hourly_prices/coin_gecko2/silver__all_prices_coingecko2.sql
@@ -176,8 +176,6 @@ final_history AS (
         base_history
     WHERE
         id IS NOT NULL
-        AND close <> 0
-        AND recorded_hour :: DATE <> '1970-01-01'
     GROUP BY
         source,
         recorded_hour,

--- a/models/silver/hourly_prices/coin_gecko2/silver__all_prices_coingecko2.sql
+++ b/models/silver/hourly_prices/coin_gecko2/silver__all_prices_coingecko2.sql
@@ -176,6 +176,8 @@ final_history AS (
         base_history
     WHERE
         id IS NOT NULL
+        AND close <> 0
+        AND recorded_hour :: DATE <> '1970-01-01'
     GROUP BY
         source,
         recorded_hour,

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -734,3 +734,8 @@ sources:
       - name: complete_event_abis
       - name: abis
       - name: traces
+  - name: github_actions
+    database: crosschain
+    schema: github_actions
+    tables:
+      - name: workflows

--- a/models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_history.sql
+++ b/models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_MARKET_CHART_API/COINGECKO', 'sql_limit', {{var('sql_limit','50000')}}, 'producer_batch_size', {{var('producer_batch_size','50000')}}, 'worker_batch_size', {{var('worker_batch_size','12500')}}, 'sm_secret_name','prod/coingecko/rest'))",
+        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_MARKET_CHART_API/COINGECKO', 'sql_limit', {{var('sql_limit','2000')}}, 'producer_batch_size', {{var('producer_batch_size','2000')}}, 'worker_batch_size', {{var('worker_batch_size','2000')}}, 'sm_secret_name','prod/coingecko/rest'))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_cg_prices_history']
@@ -24,41 +24,34 @@ WITH assets AS (
 run_times AS (
     SELECT
         asset_id,
-        run_time :: DATE AS runtime
+        run_time
     FROM
-        assets A
+        assets
         CROSS JOIN {{ ref('streamline__runtimes_daily') }}
     WHERE
-        run_time :: DATE BETWEEN '2024-01-15' :: DATE
-        AND DATEADD('day', -1, SYSDATE()) -- temp logic for backfill
-        -- run_time :: DATE BETWEEN DATEADD('day',-{{ var("LOOKBACK", 45) }}, SYSDATE())
-        -- AND DATEADD('day', -1, SYSDATE()) -- long term logic
+        run_time >= DATEADD('day', -91, SYSDATE())
+        AND run_time <= DATEADD('day', -1, SYSDATE())
     EXCEPT
     SELECT
         id AS asset_id,
-        recorded_date :: DATE AS runtime
+        recorded_date AS run_time
     FROM
         {{ ref('streamline__hourly_prices_coingecko_complete') }}
     WHERE
-        recorded_date :: DATE < DATEADD('day', -1, SYSDATE())
-        ),
-        calls AS (
-            SELECT
-                asset_id,
-                DATE_PART(
-                    'EPOCH',
-                    runtime :: DATE
-                ) :: INTEGER AS start_time_epoch,
-                DATE_PART(
-                    'EPOCH',
-                    DATEADD('day',1,runtime :: DATE)
-                ) :: INTEGER AS end_time_epoch,
-                '{service}/api/v3/coins/' || asset_id || '/market_chart/range?vs_currency=usd&from=' || start_time_epoch || '&to=' || end_time_epoch || '&x_cg_pro_api_key={Authentication}' AS api_url
-            FROM
-                run_times
-        )
+        run_time >= DATEADD('day', -91, SYSDATE())
+        AND run_time <= DATEADD('day', -1, SYSDATE())
+),
+calls AS (
     SELECT
-        start_time_epoch AS partition_key,
+        DISTINCT asset_id,
+        '{service}/api/v3/coins/' || asset_id || '/market_chart?vs_currency=usd&days=90&interval=hourly&precision=full&x_cg_pro_api_key={Authentication}' AS api_url
+    FROM
+        run_times
+)
+SELECT
+    DATE_PART(
+        'EPOCH',
+        DATEADD('day', -91, SYSDATE()) :: DATE) AS partition_key,
         ARRAY_CONSTRUCT(
             partition_key,
             ARRAY_CONSTRUCT(
@@ -69,7 +62,7 @@ run_times AS (
                 ''
             )
         ) AS request
-    FROM
-        calls
-    ORDER BY
-        partition_key ASC
+FROM
+    calls
+ORDER BY
+    partition_key ASC

--- a/models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_history.sql
+++ b/models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_history.sql
@@ -32,9 +32,9 @@ run_times AS (
     FROM
         {{ ref('streamline__hourly_prices_coingecko_complete') }}
     WHERE
-        recorded_date >= DATEADD('day', -31, SYSDATE())
+        recorded_date >= DATEADD('day', -91, SYSDATE())
         AND recorded_date <= DATEADD('day', -1, SYSDATE())
-        --replays 90 days of prices from active tokens missing all prices within the last 30 days
+        --replays 90 days of prices from active tokens missing all prices within the last 90 days
 ),
 calls AS (
     SELECT
@@ -42,7 +42,7 @@ calls AS (
             '{{ var("ASSET_ID") }}' AS id
         {% else %}
             asset_id AS id
-        {% endif %},
+        {% endif %}, --pass unique asset_id if necessary
         CONCAT(
                 '{service}/api/v3/coins/',
                 id,


### PR DESCRIPTION
1. Builds new history model, reducing # of total requests required
2. Updates complete
3. Adds snowflake tests for workflow scheduling
4. Adds backfill model

0. [fsc-utils task set up steps](https://github.com/FlipsideCrypto/fsc-utils)
1. `dbt run -m models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_complete.sql models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_history.sql --full-refresh`
2. backfill adhoc (run up to 14k): `dbt run -m models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_backfill_range.sql --vars '{"RANGE_START":1001,"RANGE_END":2000}'`
