### PR TITLE
AN-4729/xchain-quantum

### DIFF
--- a/.github/workflows/dbt_run_dev_refresh.yml
+++ b/.github/workflows/dbt_run_dev_refresh.yml
@@ -38,3 +38,4 @@ jobs:
       - name: Run DBT Jobs
         run: |
           dbt run-operation run_sp_create_prod_clone
+          dbt run-operation fsc_utils.create_udf_bulk_rest_api_v2 --vars '{"UPDATE_UDFS_AND_SPS":True}' --target dev

--- a/.github/workflows/dbt_run_dev_refresh.yml
+++ b/.github/workflows/dbt_run_dev_refresh.yml
@@ -39,3 +39,4 @@ jobs:
         run: |
           dbt run-operation run_sp_create_prod_clone
           dbt run-operation fsc_utils.create_udf_bulk_rest_api_v2 --vars '{"UPDATE_UDFS_AND_SPS":True}' --target dev
+          dbt run -s livequery_models.deploy.core._live --vars '{"UPDATE_UDFS_AND_SPS":True}' --target dev

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -62,4 +62,4 @@ vars:
 
     prod:
       API_INTEGRATION: AWS_CROSSCHAIN_API_PROD
-      EXTERNAL_FUNCTION_URI: 35hm1qhag9.execute-api.us-east-1.amazonaws.com/prod/
+      EXTERNAL_FUNCTION_URI: y4vgsb5jk5.execute-api.us-east-1.amazonaws.com/prod/

--- a/models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_backfill_range.sql
+++ b/models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_backfill_range.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_MARKET_CHART_API/COINGECKO', 'sql_limit', {{var('sql_limit','1000')}}, 'producer_batch_size', {{var('producer_batch_size','1000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'sm_secret_name','prod/coingecko/rest'))",
+        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_MARKET_CHART_API/COINGECKO', 'sql_limit', {{var('sql_limit','1000')}}, 'producer_batch_size', {{var('producer_batch_size','1000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}
@@ -62,15 +62,12 @@ SELECT
     DATE_PART(
         'EPOCH',
         DATEADD('day', -91, SYSDATE()) :: DATE) AS partition_key,
-        ARRAY_CONSTRUCT(
-            partition_key,
-            ARRAY_CONSTRUCT(
-                'GET',
-                api_url,
-                PARSE_JSON('{}'),
-                PARSE_JSON('{}'),
-                ''
-            )
+        {{ target.database }}.live.udf_api(
+            'GET',
+            api_url,
+            NULL,
+            NULL,
+            'vault/prod/coingecko/rest'
         ) AS request
 FROM
     calls

--- a/models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_history.sql
+++ b/models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_MARKET_CHART_API/COINGECKO', 'sql_limit', {{var('sql_limit','1000')}}, 'producer_batch_size', {{var('producer_batch_size','1000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'sm_secret_name','prod/coingecko/rest'))",
+        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_MARKET_CHART_API/COINGECKO', 'sql_limit', {{var('sql_limit','1000')}}, 'producer_batch_size', {{var('producer_batch_size','1000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_cg_prices_history']
@@ -56,15 +56,12 @@ SELECT
     DATE_PART(
         'EPOCH',
         DATEADD('day', -91, SYSDATE()) :: DATE) AS partition_key,
-        ARRAY_CONSTRUCT(
-            partition_key,
-            ARRAY_CONSTRUCT(
-                'GET',
-                api_url,
-                PARSE_JSON('{}'),
-                PARSE_JSON('{}'),
-                ''
-            )
+        {{ target.database }}.live.udf_api(
+            'GET',
+            api_url,
+            NULL,
+            NULL,
+            'vault/prod/coingecko/rest'
         ) AS request
 FROM
     calls

--- a/models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_realtime.sql
+++ b/models/streamline/silver/coingecko/prices/streamline__hourly_prices_coingecko_realtime.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_OHLC_API/COINGECKO', 'sql_limit', {{var('sql_limit','50000')}}, 'producer_batch_size', {{var('producer_batch_size','50000')}}, 'worker_batch_size', {{var('worker_batch_size','25000')}}, 'sm_secret_name','prod/coingecko/rest'))",
+        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_OHLC_API/COINGECKO', 'sql_limit', {{var('sql_limit','50000')}}, 'producer_batch_size', {{var('producer_batch_size','50000')}}, 'worker_batch_size', {{var('worker_batch_size','25000')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_cg_prices_realtime']
@@ -30,15 +30,12 @@ calls AS (
 )
 SELECT
     DATE_PART('EPOCH', SYSDATE()) :: INTEGER AS partition_key,
-    ARRAY_CONSTRUCT(
-        partition_key,
-        ARRAY_CONSTRUCT(
-            'GET',
-            api_url,
-            PARSE_JSON('{}'),
-            PARSE_JSON('{}'),
-            ''
-        )
+    {{ target.database }}.live.udf_api(
+        'GET',
+        api_url,
+        NULL,
+        NULL,
+        'vault/prod/coingecko/rest'
     ) AS request
 FROM
     calls

--- a/models/streamline/silver/coinmarketcap/asset_metadata/streamline__asset_metadata_coinmarketcap.sql
+++ b/models/streamline/silver/coinmarketcap/asset_metadata/streamline__asset_metadata_coinmarketcap.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_METADATA_API/COINMARKETCAP', 'sql_limit', {{var('sql_limit','10')}}, 'producer_batch_size', {{var('producer_batch_size','10')}}, 'worker_batch_size', {{var('worker_batch_size','10')}}, 'sm_secret_name','prod/prices/coinmarketcap'))",
+        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_METADATA_API/COINMARKETCAP', 'sql_limit', {{var('sql_limit','10')}}, 'producer_batch_size', {{var('producer_batch_size','10')}}, 'worker_batch_size', {{var('worker_batch_size','10')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_cmc_asset_metadata']
@@ -14,15 +14,12 @@ WITH calls AS (
 )
 SELECT
     DATE_PART('EPOCH', SYSDATE()) :: INTEGER AS partition_key,
-    ARRAY_CONSTRUCT(
-        partition_key,
-        ARRAY_CONSTRUCT(
-            'GET',
-            api_url,
-            PARSE_JSON('{"Accept": "application/json", "Accept-Encoding": "deflate, gzip", "X-CMC_PRO_API_KEY": "{Authentication}"}'),
-            PARSE_JSON('{}'),
-            ''
-        ) 
+    {{ target.database }}.live.udf_api(
+        'GET',
+        api_url,
+        PARSE_JSON('{"Accept": "application/json", "Accept-Encoding": "deflate, gzip", "X-CMC_PRO_API_KEY": "{Authentication}"}'),
+        NULL,
+        'vault/prod/prices/coinmarketcap'
     ) AS request
 FROM
     calls 

--- a/models/streamline/silver/coinmarketcap/prices/streamline__hourly_prices_coinmarketcap_history.sql
+++ b/models/streamline/silver/coinmarketcap/prices/streamline__hourly_prices_coinmarketcap_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_OHLC_API/COINMARKETCAP', 'sql_limit', {{var('sql_limit','50000')}}, 'producer_batch_size', {{var('producer_batch_size','50000')}}, 'worker_batch_size', {{var('worker_batch_size','25000')}}, 'sm_secret_name','prod/prices/coinmarketcap'))",
+        func = "{{this.schema}}.udf_bulk_rest_api_v2(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'ASSET_OHLC_API/COINMARKETCAP', 'sql_limit', {{var('sql_limit','50000')}}, 'producer_batch_size', {{var('producer_batch_size','50000')}}, 'worker_batch_size', {{var('worker_batch_size','25000')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     ),
     tags = ['streamline_cmc_prices_history']
@@ -76,15 +76,12 @@ calls AS (
 )
 SELECT
     end_time_epoch AS partition_key,
-    ARRAY_CONSTRUCT(
-        partition_key,
-        ARRAY_CONSTRUCT(
-            'GET',
-            api_url,
-            PARSE_JSON('{"Accept": "application/json", "Accept-Encoding": "deflate, gzip", "X-CMC_PRO_API_KEY": "{Authentication}"}'),
-            PARSE_JSON('{}'),
-            ''
-        )
+    {{ target.database }}.live.udf_api(
+        'GET',
+        api_url,
+        PARSE_JSON('{"Accept": "application/json", "Accept-Encoding": "deflate, gzip", "X-CMC_PRO_API_KEY": "{Authentication}"}'),
+        NULL,
+        'vault/prod/prices/coinmarketcap'
     ) AS request
 FROM
     calls

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -6,9 +6,9 @@ packages:
 - package: dbt-labs/dbt_utils
   version: 1.0.0
 - git: https://github.com/FlipsideCrypto/fsc-utils.git
-  revision: 827fba91abc6a5956b6e06432a7f49ac659ceef3
+  revision: e94e3d6964f10d8fcca239a64ec47bc8a230261e
 - package: calogica/dbt_date
   version: 0.7.2
 - git: https://github.com/FlipsideCrypto/livequery-models.git
-  revision: 883675b4021cc9a777e12fe6be8114ab039ab365
-sha1_hash: 79412049d713a846fb2ca60687a4481776c1788a
+  revision: 8b105444ef516f94efd6b9a420e62fe9f69277f9
+sha1_hash: 67dd22b288eb64cf9c6ce73cf0acb3370680594c

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -6,9 +6,9 @@ packages:
 - package: dbt-labs/dbt_utils
   version: 1.0.0
 - git: https://github.com/FlipsideCrypto/fsc-utils.git
-  revision: e94e3d6964f10d8fcca239a64ec47bc8a230261e
+  revision: 484e9db07d2060286768bb745e1b0e879178d43b
 - package: calogica/dbt_date
   version: 0.7.2
 - git: https://github.com/FlipsideCrypto/livequery-models.git
-  revision: 8b105444ef516f94efd6b9a420e62fe9f69277f9
-sha1_hash: 67dd22b288eb64cf9c6ce73cf0acb3370680594c
+  revision: b024188be4e9c6bc00ed77797ebdc92d351d620e
+sha1_hash: 13b5051fce301b1d3b2eb913d3721ea3e3f8eb5b

--- a/packages.yml
+++ b/packages.yml
@@ -6,4 +6,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: "v1.20.2"
+    revision: "v1.22.0"

--- a/packages.yml
+++ b/packages.yml
@@ -6,4 +6,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: "v1.22.0"
+    revision: "v1.23.0"


### PR DESCRIPTION
1. Upgrades request structure for quantum
2. Updates fsc-utils package version to support quantum + vault secrets for github tasks
3. for Tasks: `dbt run -s livequery_models.deploy.marketplace.github --vars '{UPDATE_UDFS_AND_SPS: true}' -t prod`