### PR TITLE
AN-4766/add-blast-core-stats

### DIFF
--- a/models/sources.yml
+++ b/models/sources.yml
@@ -666,6 +666,11 @@ sources:
     schema: stats
     tables:
       - name: ez_core_metrics_hourly
+  - name: blast_stats
+    database: blast
+    schema: stats
+    tables:
+      - name: ez_core_metrics_hourly
   - name: base_stats
     database: base
     schema: stats


### PR DESCRIPTION
Merge after [Blast PR](https://github.com/FlipsideCrypto/blast-models/pull/40) and perms are configured

`dbt run -m models/silver/stats/silver__complete_core_metrics_hourly.sql --vars '{"HEAL_CURATED_MODEL":"blast"}'`