### PR TITLE
AN-4890/base58

### DIFF
--- a/.github/workflows/dbt_run_dev_refresh.yml
+++ b/.github/workflows/dbt_run_dev_refresh.yml
@@ -2,7 +2,6 @@ name: dbt_run_dev_refresh
 run-name: dbt_run_dev_refresh
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 3 * * *'
     

--- a/.github/workflows/dbt_run_dev_refresh.yml
+++ b/.github/workflows/dbt_run_dev_refresh.yml
@@ -2,6 +2,7 @@ name: dbt_run_dev_refresh
 run-name: dbt_run_dev_refresh
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 3 * * *'
     

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -6,9 +6,9 @@ packages:
 - package: dbt-labs/dbt_utils
   version: 1.0.0
 - git: https://github.com/FlipsideCrypto/fsc-utils.git
-  revision: 484e9db07d2060286768bb745e1b0e879178d43b
+  revision: e64c8604eb0cdbde3e2d181e2dff2e85b465e098
 - package: calogica/dbt_date
   version: 0.7.2
 - git: https://github.com/FlipsideCrypto/livequery-models.git
   revision: b024188be4e9c6bc00ed77797ebdc92d351d620e
-sha1_hash: 13b5051fce301b1d3b2eb913d3721ea3e3f8eb5b
+sha1_hash: 7fe367bea41914426512d24318e4be85f6d39f67

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -6,9 +6,9 @@ packages:
 - package: dbt-labs/dbt_utils
   version: 1.0.0
 - git: https://github.com/FlipsideCrypto/fsc-utils.git
-  revision: e64c8604eb0cdbde3e2d181e2dff2e85b465e098
+  revision: f285fe2bdbbf50931d80d6628899b763a02cf26c
 - package: calogica/dbt_date
   version: 0.7.2
 - git: https://github.com/FlipsideCrypto/livequery-models.git
   revision: b024188be4e9c6bc00ed77797ebdc92d351d620e
-sha1_hash: 7fe367bea41914426512d24318e4be85f6d39f67
+sha1_hash: 88d7e40287de2d2298d89b0a87d1a11dcba8106b

--- a/packages.yml
+++ b/packages.yml
@@ -6,4 +6,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: "v1.23.0"
+    revision: "v1.26.0"

--- a/packages.yml
+++ b/packages.yml
@@ -6,4 +6,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: "v1.26.0"
+    revision: "v1.28.0"


### PR DESCRIPTION
Merge after [this PR](https://github.com/FlipsideCrypto/fsc-utils/pull/44)
1. Updates fsc-utils version tag: `v1.28.0`
2. Requires udf redeployment `dbt run-operation fsc_utils.create_udfs --vars '{UPDATE_UDFS_AND_SPS: true}' --target prod`