### PR TITLE
use fact_swaps_id as unique key for solana swaps

### DIFF
--- a/models/silver/defi/silver__complete_dex_swaps.sql
+++ b/models/silver/defi/silver__complete_dex_swaps.sql
@@ -401,8 +401,8 @@ solana AS (
         NULL AS amount_out_usd,
         _log_id,
         modified_timestamp AS _inserted_timestamp,
-        {{ dbt_utils.generate_surrogate_key(['_log_id','blockchain']) }} AS complete_dex_swaps_id,
-        {{ dbt_utils.generate_surrogate_key(['_log_id','blockchain']) }} AS _unique_key
+        {{ dbt_utils.generate_surrogate_key(['fact_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
+        {{ dbt_utils.generate_surrogate_key(['fact_swaps_id','blockchain']) }} AS _unique_key
     FROM
         {{ source(
             'solana_defi',


### PR DESCRIPTION
Fix datadog [alert](https://app.datadoghq.com/monitors/108640720?from_ts=1724645080000&to_ts=1724646280000&event_id=7723948475004724755&source=monitor_notif) for duplicate unique key

```
15:49:40  1 of 1 OK created sql incremental model silver.complete_dex_swaps .............. [SUCCESS 27753747 in 367.74s]
```