### PR TITLE
add eclipse stats

### DIFF
--- a/models/silver/stats/silver__complete_core_metrics_hourly.sql
+++ b/models/silver/stats/silver__complete_core_metrics_hourly.sql
@@ -763,6 +763,42 @@ WHERE
     )
 {% endif %}
 ),
+eclipse AS (
+    SELECT
+        'eclipse' AS blockchain,
+        block_timestamp_hour,
+        block_number_min,
+        block_number_max,
+        block_count,
+        transaction_count,
+        transaction_count_success,
+        transaction_count_failed,
+        unique_signers_count AS unique_initiator_count,
+        total_fees_native,
+        total_fees_usd,
+        modified_timestamp AS _inserted_timestamp,
+        {{ dbt_utils.generate_surrogate_key(
+            ['ez_core_metrics_hourly_id','blockchain']
+        ) }} AS core_metrics_hourly_id
+    FROM
+        {{ source(
+            'eclipse_stats',
+            'ez_core_metrics_hourly'
+        ) }}
+
+{% if is_incremental() and 'eclipse' not in var('HEAL_MODELS') %}
+WHERE
+    DATE_TRUNC(
+        'hour',
+        _inserted_timestamp
+    ) >= (
+        SELECT
+            MAX(DATE_TRUNC('hour', _inserted_timestamp)) - INTERVAL '{{ var("LOOKBACK", "12 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
+),
 all_chains AS (
     SELECT
         *
@@ -868,6 +904,11 @@ all_chains AS (
         *
     FROM
         lava
+    UNION ALL
+    SELECT
+        *
+    FROM
+        eclipse
 )
 SELECT
     blockchain,

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -810,6 +810,11 @@ sources:
     schema: stats
     tables:
       - name: ez_core_metrics_hourly
+  - name: eclipse_stats
+    database: eclipse
+    schema: stats
+    tables:
+      - name: ez_core_metrics_hourly
   - name: blast_silver
     database: blast
     schema: silver


### PR DESCRIPTION
- Add `eclipse_stats` to `silver__complete_core_metrics_hourly`

tests pass
```
14:45:32  Finished running 12 tests, 5 hooks in 0 hours 0 minutes and 17.32 seconds (17.32s).
14:45:32  
14:45:32  Completed successfully
14:45:32  
14:45:32  Done. PASS=12 WARN=0 ERROR=0 SKIP=0 TOTAL=12
```

eclipse data in dev
```
select *
from crosschain_dev.silver.complete_core_metrics_hourly
where blockchain = 'eclipse';
```