### PR TITLE
AN-5301/blast-defi-dex

### DIFF
--- a/models/gold/defi/defi__dim_dex_liquidity_pools.sql
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.sql
@@ -198,6 +198,33 @@ WITH base AS (
         ) }}
     UNION ALL
     SELECT
+        'blast' AS blockchain,
+        platform,
+        block_number,
+        block_timestamp,
+        tx_hash,
+        contract_address,
+        pool_address,
+        pool_name,
+        tokens,
+        symbols,
+        decimals,
+        COALESCE(
+            inserted_timestamp,
+            '2000-01-01'
+        ) AS inserted_timestamp,
+        COALESCE(
+            modified_timestamp,
+            '2000-01-01'
+        ) AS modified_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['blockchain','pool_address']) }} AS dim_dex_liquidity_pools_id
+    FROM
+        {{ source(
+            'blast_silver_dex',
+            'complete_dex_liquidity_pools'
+        ) }}
+    UNION ALL
+    SELECT
         'gnosis' AS blockchain,
         platform,
         block_number,

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.sql
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.sql
@@ -209,14 +209,8 @@ WITH base AS (
         tokens,
         symbols,
         decimals,
-        COALESCE(
-            inserted_timestamp,
-            '2000-01-01'
-        ) AS inserted_timestamp,
-        COALESCE(
-            modified_timestamp,
-            '2000-01-01'
-        ) AS modified_timestamp,
+        inserted_timestamp,
+        modified_timestamp,
         {{ dbt_utils.generate_surrogate_key(['blockchain','pool_address']) }} AS dim_dex_liquidity_pools_id
     FROM
         {{ source(

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.yml
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: defi__dim_dex_liquidity_pools
-    description: A comprehensive dim table holding blockchain and platform specific decentralized exchange pools. This table contains liquidity pools from Ethereum, Optimism, Polygon, BSC, BASE, Gnosis, and Arbitrum.
+    description: A comprehensive dim table holding blockchain and platform specific decentralized exchange pools.
 
     columns:
       - name: BLOCKCHAIN

--- a/models/gold/defi/defi__ez_dex_swaps.yml
+++ b/models/gold/defi/defi__ez_dex_swaps.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: defi__ez_dex_swaps
-    description: A comprehensive convenience table holding blockchain and platform specific decentralized exchange swaps. This table contains dex swaps from Arbitrum, Avalanche, Base, BSC, Gnosis, Ethereum, Optimism, Polygon, Osmosis, Solana, and Near.
+    description: A comprehensive convenience table holding blockchain and platform specific decentralized exchange swaps.
     
     columns:
       - name: BLOCKCHAIN

--- a/models/gold/defi/defi__fact_dex_swaps.yml
+++ b/models/gold/defi/defi__fact_dex_swaps.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: defi__fact_dex_swaps
-    description: A comprehensive fact table holding blockchain and platform specific decentralized exchange swaps. This table contains dex swaps from Arbitrum, Avalanche, Base, BSC, Gnosis, Ethereum, Optimism, Polygon, Osmosis, Solana, and Near.
+    description: A comprehensive fact table holding blockchain and platform specific decentralized exchange swaps.
 
     columns:
       - name: BLOCKCHAIN

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -447,7 +447,6 @@ sources:
     database: blast
     schema: silver_dex
     tables:
-      - name: complete_dex_swaps
       - name: complete_dex_liquidity_pools
   - name: solana_silver
     database: solana

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -158,6 +158,11 @@ sources:
       - name: ez_lending_liquidations
       - name: ez_lending_repayments
       - name: ez_lending_withdraws      
+  - name: blast_defi
+    database: blast
+    schema: defi
+    tables:
+      - name: ez_dex_swaps
   - name: polygon_silver
     database: polygon
     schema: silver
@@ -434,6 +439,12 @@ sources:
       - name: complete_dex_liquidity_pools
   - name: arbitrum_silver_dex
     database: arbitrum
+    schema: silver_dex
+    tables:
+      - name: complete_dex_swaps
+      - name: complete_dex_liquidity_pools
+  - name: blast_silver_dex
+    database: blast
     schema: silver_dex
     tables:
       - name: complete_dex_swaps


### PR DESCRIPTION
1. Adds Blast DEX Liquidity Pools and Swaps
2. Requires `dbt run -m models/gold/defi/defi__dim_dex_liquidity_pools.sql models/silver/defi/silver__complete_dex_swaps.sql --vars '{"HEAL_MODELS":"blast"}'`