### PR TITLE
Update silver__number_sequence.sql

### DIFF
--- a/models/silver/utilities/silver__number_sequence.sql
+++ b/models/silver/utilities/silver__number_sequence.sql
@@ -5,9 +5,6 @@
 ) }}
 
 SELECT
-    ROW_NUMBER() over (
-        ORDER BY
-            SEQ4()
-    ) :: INT AS _id
+    SEQ4() AS _id
 FROM
     TABLE(GENERATOR(rowcount => 1000000000))


### PR DESCRIPTION
Using `seq4()` directly instead of applying `row_number()` lets the count start at 0