### PR TITLE
add/abi-chains

### DIFF
--- a/models/gold/core/core__dim_evm_event_abis.sql
+++ b/models/gold/core/core__dim_evm_event_abis.sql
@@ -4,7 +4,8 @@
     "columns": true }
 ) }}
 
-{% set models = [ ('ethereum', source('ethereum_silver', 'complete_event_abis')), 
+{% set models = [ 
+('ethereum', source('ethereum_silver', 'complete_event_abis')), 
 ('polygon', source('polygon_silver', 'complete_event_abis')) , 
 ('bsc', source('bsc_silver', 'complete_event_abis')) , 
 ('avalanche', source('avalanche_silver', 'complete_event_abis')) , 
@@ -13,7 +14,12 @@
 ('base', source('base_silver', 'complete_event_abis')),
 ('blast', source('blast_silver', 'complete_event_abis')),
 ('kaia', source('kaia_silver', 'complete_event_abis')),
-('optimism', source('optimism_silver', 'complete_event_abis')) ] 
+('optimism', source('optimism_silver', 'complete_event_abis')),
+('mantle', source('mantle_silver', 'complete_event_abis')),
+('core', source('core_silver', 'complete_event_abis')),
+('sei', source('sei_evm_silver', 'complete_event_abis')),
+('berachain-bartio', source('berachain_bartio_silver', 'complete_event_abis'))
+ ] 
 %}
 SELECT *
 FROM (

--- a/models/silver/core/abis/silver__abis.sql
+++ b/models/silver/core/abis/silver__abis.sql
@@ -18,6 +18,8 @@
     ('sei', source('sei_evm_silver', 'abis')),
     ('kaia', source('kaia_silver', 'abis')),
     ('berachain-bartio', source('berachain_bartio_silver', 'abis')),
+    ('mantle', source('mantle_silver', 'abis')),
+    ('core', source('core_silver', 'abis'))
 ]
 %}
 

--- a/models/silver/core/abis/silver__event_abis.sql
+++ b/models/silver/core/abis/silver__event_abis.sql
@@ -5,7 +5,8 @@
 
 
 
-{% set models = [ ('ethereum', source('ethereum_silver', 'complete_event_abis')), 
+{% set models = [ 
+('ethereum', source('ethereum_silver', 'complete_event_abis')), 
 ('polygon', source('polygon_silver', 'complete_event_abis')) , 
 ('bsc', source('bsc_silver', 'complete_event_abis')) , 
 ('avalanche', source('avalanche_silver', 'complete_event_abis')) , 
@@ -14,7 +15,12 @@
 ('optimism', source('optimism_silver', 'complete_event_abis')),
 ('base', source('base_silver', 'complete_event_abis')),
 ('blast', source('blast_silver', 'complete_event_abis')),  
-('kaia', source('kaia_silver', 'complete_event_abis')) ] 
+('kaia', source('kaia_silver', 'complete_event_abis')),
+('mantle', source('mantle_silver', 'complete_event_abis')),
+('core', source('core_silver', 'complete_event_abis')),
+('sei', source('sei_evm_silver', 'complete_event_abis')),
+('berachain-bartio', source('berachain_bartio_silver', 'complete_event_abis'))
+ ] 
 %}
 SELECT *
 FROM (

--- a/models/silver/core/silver__contracts.sql
+++ b/models/silver/core/silver__contracts.sql
@@ -257,6 +257,106 @@ WITH base AS (
     UNION ALL
     SELECT
         address,
+        symbol,
+        NAME,
+        decimals,
+        created_block_number,
+        created_block_timestamp,
+        created_tx_hash,
+        creator_address,
+        'mantle' AS blockchain,
+        COALESCE(
+            inserted_timestamp,
+            '2000-01-01'
+        ) AS inserted_timestamp,
+        COALESCE(
+            modified_timestamp,
+            '2000-01-01'
+        ) AS modified_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['blockchain','address']) }} AS dim_contracts_id
+    FROM
+        {{ source(
+            'mantle_core',
+            'dim_contracts'
+        ) }}
+    UNION ALL
+    SELECT
+        address,
+        symbol,
+        NAME,
+        decimals,
+        created_block_number,
+        created_block_timestamp,
+        created_tx_hash,
+        creator_address,
+        'core' AS blockchain,
+        COALESCE(
+            inserted_timestamp,
+            '2000-01-01'
+        ) AS inserted_timestamp,
+        COALESCE(
+            modified_timestamp,
+            '2000-01-01'
+        ) AS modified_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['blockchain','address']) }} AS dim_contracts_id
+    FROM
+        {{ source(
+            'core_core',
+            'dim_contracts'
+        ) }}
+    UNION ALL
+    SELECT
+        address,
+        symbol,
+        NAME,
+        decimals,
+        created_block_number,
+        created_block_timestamp,
+        created_tx_hash,
+        creator_address,
+        'sei' AS blockchain,
+        COALESCE(
+            inserted_timestamp,
+            '2000-01-01'
+        ) AS inserted_timestamp,
+        COALESCE(
+            modified_timestamp,
+            '2000-01-01'
+        ) AS modified_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['blockchain','address']) }} AS dim_contracts_id
+    FROM
+        {{ source(
+            'sei_evm_core',
+            'dim_contracts'
+        ) }}
+    UNION ALL
+    SELECT
+        address,
+        symbol,
+        NAME,
+        decimals,
+        created_block_number,
+        created_block_timestamp,
+        created_tx_hash,
+        creator_address,
+        'berachain-bartio' AS blockchain,
+        COALESCE(
+            inserted_timestamp,
+            '2000-01-01'
+        ) AS inserted_timestamp,
+        COALESCE(
+            modified_timestamp,
+            '2000-01-01'
+        ) AS modified_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['blockchain','address']) }} AS dim_contracts_id
+    FROM
+        {{ source(
+            'berachain_bartio_testnet',
+            'dim_contracts'
+        ) }}
+    UNION ALL
+    SELECT
+        address,
         LOWER(project_name) AS symbol,
         label AS NAME,
         DECIMAL AS decimals,

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -836,6 +836,28 @@ sources:
       - name: traces
       - name: blocks
       - name: decoded_logs
+  - name: mantle_silver
+    database: mantle
+    schema: silver
+    tables:
+      - name: complete_event_abis
+      - name: abis
+  - name: mantle_core
+    database: mantle
+    schema: core
+    tables:
+      - name: dim_contracts
+  - name: core_silver
+    database: core
+    schema: silver
+    tables:
+      - name: complete_event_abis
+      - name: abis
+  - name: core_core
+    database: core
+    schema: core
+    tables:
+      - name: dim_contracts
   - name: blast_core
     database: blast
     schema: core
@@ -869,6 +891,12 @@ sources:
     schema: silver_evm
     tables:
       - name: abis
+      - name: complete_event_abis
+  - name: sei_evm_core
+    database: sei
+    schema: core_evm
+    tables:
+      - name: dim_contracts
   - name: ethereum_silver_olas
     database: ethereum
     schema: silver_olas
@@ -960,6 +988,12 @@ sources:
     schema: silver_testnet
     tables:
       - name: abis
+      - name: complete_event_abis
+  - name: berachain_bartio_testnet
+    database: berachain
+    schema: testnet
+    tables:
+      - name: dim_contracts
   - name: aleo_stats
     database: aleo
     schema: stats


### PR DESCRIPTION
1. Adds new and missing chains to contracts and ABI views

`dbt run -m models/silver/core/abis models/gold/core/core__dim_evm_event_abis.sql models/silver/core/silver__contracts.sql --full-refresh`