### PR TITLE
add/ink-contracts

### DIFF
--- a/models/silver/core/abis/silver__abis.sql
+++ b/models/silver/core/abis/silver__abis.sql
@@ -21,6 +21,7 @@
     ('mantle', source('mantle_silver', 'abis')),
     ('ronin', source('ronin_silver', 'abis')),
     ('swell', source('swell_silver', 'abis')),
+    ('ink', source('ink_silver', 'abis')),
     ('core', source('core_silver', 'abis'))
 ]
 %}

--- a/models/silver/core/abis/silver__abis.sql
+++ b/models/silver/core/abis/silver__abis.sql
@@ -22,6 +22,7 @@
     ('ronin', source('ronin_silver', 'abis')),
     ('swell', source('swell_silver', 'abis')),
     ('ink', source('ink_silver', 'abis')),
+    ('bob', source('bob_silver', 'abis')),
     ('core', source('core_silver', 'abis'))
 ]
 %}

--- a/models/silver/core/abis/silver__event_abis.sql
+++ b/models/silver/core/abis/silver__event_abis.sql
@@ -22,6 +22,7 @@
 ('ronin', source('ronin_silver', 'complete_event_abis')),
 ('swell', source('swell_silver', 'complete_event_abis')),
 ('ink', source('ink_silver', 'complete_event_abis')),
+('bob', source('bob_silver', 'complete_event_abis')),
 ('berachain-bartio', source('berachain_bartio_silver', 'complete_event_abis'))
  ] 
 %}

--- a/models/silver/core/abis/silver__event_abis.sql
+++ b/models/silver/core/abis/silver__event_abis.sql
@@ -21,6 +21,7 @@
 ('sei', source('sei_evm_silver', 'complete_event_abis')),
 ('ronin', source('ronin_silver', 'complete_event_abis')),
 ('swell', source('swell_silver', 'complete_event_abis')),
+('ink', source('ink_silver', 'complete_event_abis')),
 ('berachain-bartio', source('berachain_bartio_silver', 'complete_event_abis'))
  ] 
 %}

--- a/models/silver/core/silver__contracts.sql
+++ b/models/silver/core/silver__contracts.sql
@@ -405,6 +405,31 @@ WITH base AS (
             'dim_contracts'
         ) }}
     UNION ALL
+        SELECT
+        address,
+        symbol,
+        NAME,
+        decimals,
+        created_block_number,
+        created_block_timestamp,
+        created_tx_hash,
+        creator_address,
+        'ink' AS blockchain,
+        COALESCE(
+            inserted_timestamp,
+            '2000-01-01'
+        ) AS inserted_timestamp,
+        COALESCE(
+            modified_timestamp,
+            '2000-01-01'
+        ) AS modified_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['blockchain','address']) }} AS dim_contracts_id
+    FROM
+        {{ source(
+            'ink_core',
+            'dim_contracts'
+        ) }}
+    UNION ALL
     SELECT
         address,
         LOWER(project_name) AS symbol,

--- a/models/silver/core/silver__contracts.sql
+++ b/models/silver/core/silver__contracts.sql
@@ -405,7 +405,7 @@ WITH base AS (
             'dim_contracts'
         ) }}
     UNION ALL
-        SELECT
+    SELECT
         address,
         symbol,
         NAME,
@@ -427,6 +427,31 @@ WITH base AS (
     FROM
         {{ source(
             'ink_core',
+            'dim_contracts'
+        ) }}
+    UNION ALL
+    SELECT
+        address,
+        symbol,
+        NAME,
+        decimals,
+        created_block_number,
+        created_block_timestamp,
+        created_tx_hash,
+        creator_address,
+        'bob' AS blockchain,
+        COALESCE(
+            inserted_timestamp,
+            '2000-01-01'
+        ) AS inserted_timestamp,
+        COALESCE(
+            modified_timestamp,
+            '2000-01-01'
+        ) AS modified_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['blockchain','address']) }} AS dim_contracts_id
+    FROM
+        {{ source(
+            'bob_core',
             'dim_contracts'
         ) }}
     UNION ALL

--- a/models/silver/prices/complete/silver__complete_token_asset_metadata.sql
+++ b/models/silver/prices/complete/silver__complete_token_asset_metadata.sql
@@ -96,7 +96,7 @@ heal_model AS (
                     FROM
                         {{ ref('core__dim_contracts') }} C
                     WHERE
-                        C.modified_timestamp > DATEADD('DAY', -14, SYSDATE())
+                        C.modified_timestamp > DATEADD('DAY', -90, SYSDATE())
                         AND C.decimals IS NOT NULL
                         AND LOWER(
                             C.address
@@ -130,7 +130,7 @@ heal_model AS (
                     FROM
                         {{ ref('core__dim_contracts') }} C
                     WHERE
-                        C.modified_timestamp > DATEADD('DAY', -14, SYSDATE())
+                        C.modified_timestamp > DATEADD('DAY', -90, SYSDATE())
                         AND C.symbol IS NOT NULL
                         AND LOWER(
                             C.address

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -1042,6 +1042,17 @@ sources:
     schema: core
     tables:
       - name: dim_contracts
+  - name: ink_silver
+    database: ink
+    schema: silver
+    tables:
+      - name: abis
+      - name: complete_event_abis
+  - name: ink_core
+    database: ink
+    schema: core
+    tables:
+      - name: dim_contracts
   - name: aleo_stats
     database: aleo
     schema: stats

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -1053,6 +1053,17 @@ sources:
     schema: core
     tables:
       - name: dim_contracts
+  - name: bob_silver
+    database: bob
+    schema: silver
+    tables:
+      - name: abis
+      - name: complete_event_abis
+  - name: bob_core
+    database: bob
+    schema: core
+    tables:
+      - name: dim_contracts
   - name: aleo_stats
     database: aleo
     schema: stats


### PR DESCRIPTION
1. Add `ink` contracts and abis
2. Adjust lookback on token asset metadata heal to capture more decimals

`dbt run -m models/silver/core/abis models/silver/core/silver__contracts.sql models/gold/core/core__dim_contracts.sql --full-refresh` + run `heal` workflow