### PR TITLE
add/update-prices-macro

### DIFF
--- a/macros/prices/update_blockchain.sql
+++ b/macros/prices/update_blockchain.sql
@@ -1,0 +1,22 @@
+{% macro update_blockchain(new_blockchain_name, current_blockchain_names) %}
+
+{% for table in [
+    'crosschain.silver.token_prices_all_providers',
+    'crosschain.silver.token_asset_metadata_all_providers',
+    'crosschain.silver.token_asset_metadata_priority',
+    'crosschain.silver.token_prices_priority',
+    'crosschain.silver.complete_token_asset_metadata',
+    'crosschain.silver.complete_token_prices'
+] %}
+
+{% set sql %}
+UPDATE {{ table }}
+SET blockchain = '{{ new_blockchain_name }}'
+WHERE blockchain IN ({{ current_blockchain_names | join(", ") }});
+{% endset %}
+
+{% do run_query(sql) %}
+
+{% endfor %}
+
+{% endmacro %}


### PR DESCRIPTION
1. Adds a macro to apply update statements when a blockchain name needs to be normalized in the prices pipeline
2. Requires an update to `silver__token_prices_all_providers` and `silver__token_asset_metadata_all_providers`
3. Example [PR ](https://github.com/FlipsideCrypto/crosschain-models/pull/438/files)