### PR TITLE
unifai purchase txs

### DIFF
--- a/.github/workflows/dbt_run_streamline_unifai_txs.yml
+++ b/.github/workflows/dbt_run_streamline_unifai_txs.yml
@@ -41,7 +41,8 @@ jobs:
           dbt deps
       - name: Run DBT Jobs
         run: |
-          dbt run -s streamline__unifai_swap_txs_complete streamline__unifai_swap_txs_realtime --vars '{STREAMLINE_INVOKE_STREAMS: True}'
+          dbt run -m 2+streamline__unifai_swap_txs_complete streamline__unifai_swap_txs_realtime --vars '{STREAMLINE_INVOKE_STREAMS: True}'
+          dbt run -m 2+streamline__unifai_purchase_txs_complete streamline__unifai_purchase_txs_realtime --vars '{STREAMLINE_INVOKE_STREAMS: True}'
 
   notify-failure:
     needs: [run_dbt_jobs]

--- a/models/bronze/unifai/bronze__streamline_FR_unifai_purchase_txs.sql
+++ b/models/bronze/unifai/bronze__streamline_FR_unifai_purchase_txs.sql
@@ -1,0 +1,10 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "unifai_purchase_txs" %}
+{{ streamline_external_table_FR_query_v2(
+    model,
+    partition_function = "CAST(SPLIT_PART(file_name, '/', 3) AS STRING )"
+) }}
+

--- a/models/bronze/unifai/bronze__streamline_unifai_purchase_txs.sql
+++ b/models/bronze/unifai/bronze__streamline_unifai_purchase_txs.sql
@@ -1,0 +1,9 @@
+{{ config (
+    materialized = 'view'
+) }}
+
+{% set model = "unifai_purchase_txs" %}
+{{ streamline_external_table_query_v2(
+    model,
+    partition_function = "CAST(SPLIT_PART(file_name, '/', 3) AS STRING )"
+) }}

--- a/models/silver/unifai/silver__unifai_purchases.sql
+++ b/models/silver/unifai/silver__unifai_purchases.sql
@@ -1,0 +1,50 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ['unifai_purchases_id'],
+    incremental_strategy = 'delete+insert',
+    cluster_by = ['created_at_timestamp::DATE','_inserted_timestamp::DATE'],
+    tags = ['unifai_daily']
+) }}
+-- depends_on: {{ ref('bronze__streamline_unifai_purchase_txs') }}
+-- depends_on: {{ ref('bronze__streamline_FR_unifai_purchase_txs') }}
+
+{% if execute %}
+    {% if is_incremental() %}
+    {% set max_inserted_query %}
+    SELECT
+        MAX(_inserted_timestamp) AS _inserted_timestamp
+    FROM
+        {{ this }}
+    {% endset %}
+    {% set max_inserted_timestamp = run_query(max_inserted_query)[0][0] %}
+    {% endif %}
+{% endif %}
+
+SELECT
+    data:createdAt::timestamp_ntz AS created_at_timestamp,
+    data:txHash::string as tx_hash,
+    data:chain::string as chain,
+    data:status::string as status,
+    data:fromAddress::string as from_address,
+    data:toAddress::string as to_address,
+    data:tokenAmount::FLOAT as token_amount,
+    data:tokenSymbol::string as token_symbol,
+    data:tokenValue::FLOAT as token_value,
+    data:user::string as user,
+    partition_key,
+    _inserted_timestamp,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['tx_hash', 'chain']) }} AS unifai_purchases_id,
+    '{{ invocation_id }}' AS _invocation_id
+FROM 
+
+{% if is_incremental() %}
+    {{ ref('bronze__streamline_unifai_purchase_txs') }}
+WHERE 
+    _inserted_timestamp >= '{{ max_inserted_timestamp }}'
+{% else %}
+    {{ ref('bronze__streamline_FR_unifai_purchase_txs') }} a
+{% endif %}
+QUALIFY
+    row_number() OVER (PARTITION BY created_at_timestamp, tx_hash, chain ORDER BY _inserted_timestamp DESC) = 1

--- a/models/silver/unifai/silver__unifai_purchases.yml
+++ b/models/silver/unifai/silver__unifai_purchases.yml
@@ -1,0 +1,56 @@
+version: 2
+models:
+  - name: silver__unifai_purchases
+    recent_date_filter: &recent_date_filter
+      config:
+        where: _inserted_timestamp >= current_date - 7
+    columns:
+      - name: CREATED_AT_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: TX_HASH
+        tests:
+          - not_null: *recent_date_filter
+          - unique:
+              config:
+                where: >
+                  _inserted_timestamp::date >= current_date - 7
+      - name: CHAIN
+        tests:
+          - not_null: *recent_date_filter
+      - name: STATUS
+        tests:
+          - not_null: *recent_date_filter
+      - name: FROM_ADDRESS
+        tests:
+          - not_null: *recent_date_filter
+      - name: TO_ADDRESS
+        tests:
+          - not_null: *recent_date_filter
+      - name: TOKEN_AMOUNT
+        tests:
+          - not_null: *recent_date_filter
+      - name: TOKEN_SYMBOL
+        tests:
+          - not_null: *recent_date_filter
+      - name: TOKEN_VALUE
+        tests:
+          - not_null: *recent_date_filter
+      - name: USER
+        tests:
+          - not_null: *recent_date_filter
+      - name: _INSERTED_TIMESTAMP
+        data_tests: 
+          - not_null
+      - name: UNIFAI_PURCHASES_ID
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: INSERTED_TIMESTAMP
+        data_tests: 
+          - not_null: *recent_date_filter
+      - name: MODIFIED_TIMESTAMP
+        data_tests: 
+          - not_null: *recent_date_filter

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -428,6 +428,7 @@ sources:
       - name: asset_metadata_coin_market_cap_api_v2
       - name: asset_ohlc_coin_market_cap_api_v2
       - name: unifai_swap_txs
+      - name: unifai_purchase_txs
   - name: bronze
     database: crosschain
     schema: bronze

--- a/models/streamline/unifai/streamline__unifai_purchase_txs_complete.sql
+++ b/models/streamline/unifai/streamline__unifai_purchase_txs_complete.sql
@@ -1,0 +1,24 @@
+{{ config (
+    materialized = "incremental",
+    unique_key = ['partition_key'],
+    cluster_by = "partition_key"
+) }}
+
+SELECT
+    partition_key,
+    TO_TIMESTAMP_NTZ(partition_key, 'YYYY_MM_DD') as run_date,
+    max(_inserted_timestamp) as _inserted_timestamp
+FROM
+    {{ ref('bronze__streamline_unifai_purchase_txs') }}
+
+{% if is_incremental() %}
+where _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+)
+{% endif %}
+GROUP BY 1,2
+
+

--- a/models/streamline/unifai/streamline__unifai_purchase_txs_realtime.sql
+++ b/models/streamline/unifai/streamline__unifai_purchase_txs_realtime.sql
@@ -1,0 +1,46 @@
+{{ config (
+    materialized = "view",
+    post_hook = fsc_utils.if_data_call_function_v2(
+        func = 'streamline.udf_bulk_rest_api_v2',
+        target = "{{this.schema}}.{{this.identifier}}",
+        params ={ "external_table" :"UNIFAI_PURCHASE_TXS",
+        "sql_limit" :"100",
+        "producer_batch_size" :"100",
+        "worker_batch_size" :"100",
+        "sql_source": "{{this.identifier}}",
+        "exploded_key": tojson(["data"]),
+        }
+    ),
+    tags = ['streamline_unifai_purchase_txs_realtime']
+) }}
+
+WITH run_times AS (
+    SELECT
+        run_time
+    FROM {{ ref('streamline__runtimes_daily') }}
+    where run_time >= '2025-03-26'
+
+    EXCEPT
+
+    SELECT
+        run_date as run_time
+    FROM {{ ref('streamline__unifai_purchase_txs_complete') }}
+)
+
+SELECT
+    TO_CHAR(TO_TIMESTAMP_NTZ(run_time), 'YYYY_MM_DD') AS partition_key,
+    crosschain.live.udf_api(
+        'GET',
+        CONCAT(
+            '{service}purchase-txns?startDate=',
+            TO_VARCHAR(run_time, 'YYYY-MM-DD'), 'T00%3A00%3A00Z&endDate=',
+            TO_VARCHAR(run_time, 'YYYY-MM-DD'), 'T23%3A59%3A59Z'
+        ),
+        OBJECT_CONSTRUCT(
+            'Content-Type', 'application/json',
+            'Authorization', '{authentication}'
+        ),
+        {},
+        'Vault/prod/crosschain/unifai'
+    ) AS request
+from run_times


### PR DESCRIPTION
Ingestion for Unifai purchase txs - [AN-5933](https://team-1612274056224.atlassian.net/browse/AN-5933)

- create bronze and silver tables
- models will be ran daily. Ingestion will be triggered daily at 0:55 and then silver will run with dbt_run_scheduled_daily @ 2:00
- added runs to `.github/workflows/dbt_run_streamline_unifai_txs.yml`, and added 2+ so bronze models run

runs:
- realtime and complete
```
19:21:03  1 of 2 START sql incremental model streamline.unifai_purchase_txs_complete ..... [RUN]
19:21:09  1 of 2 OK created sql incremental model streamline.unifai_purchase_txs_complete  [SUCCESS 36 in 6.30s]
19:21:09  2 of 2 START sql view model streamline.unifai_purchase_txs_realtime ............ [RUN]
19:21:09  Running macro `if_data_call_function`: Calling udf streamline.udf_bulk_rest_api_v2 with params: 
{
  "exploded_key": "[\"data\"]",
  "external_table": "UNIFAI_PURCHASE_TXS",
  "producer_batch_size": "100",
  "sql_limit": "100",
  "sql_source": "{{this.identifier}}",
  "worker_batch_size": "100"
}
 on {{this.schema}}.{{this.identifier}}
19:21:18  2 of 2 OK created sql view model streamline.unifai_purchase_txs_realtime ....... [SUCCESS 1 in 8.76s]
```

- silver
`18:40:06  1 of 1 OK created sql incremental model silver.unifai_purchases ................ [SUCCESS 1 in 5.31s]`

[AN-5933]: https://team-1612274056224.atlassian.net/browse/AN-5933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ