### PR TITLE
AN-6347 dex stats

### DIFF
--- a/models/gold/defi/defi__ez_dex_swaps.sql
+++ b/models/gold/defi/defi__ez_dex_swaps.sql
@@ -3,7 +3,7 @@
     persist_docs ={ "relation": true,
     "columns": true },
     meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'DEX, SWAPS',
-    } } }
+    }} }
 ) }}
 
 SELECT
@@ -16,10 +16,12 @@ SELECT
     trader,
     token_in,
     symbol_in,
+    token_in_is_verified,
     amount_in_raw,
     amount_in,
     amount_in_usd,
     token_out,
+    token_out_is_verified,
     symbol_out,
     amount_out_raw,
     amount_out,

--- a/models/gold/stats/stats__ez_dex_metrics_daily.sql
+++ b/models/gold/stats/stats__ez_dex_metrics_daily.sql
@@ -1,0 +1,104 @@
+-- depends_on: {{ ref('defi__ez_dex_swaps') }}
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'merge',
+    merge_exclude_columns = ["inserted_timestamp"],
+    unique_key = ['blockchain','block_date'],
+    cluster_by = ['blockchain','block_date'],
+    tags = ['metrics_daily']
+) }}
+
+{% if execute %}
+
+{% if is_incremental() %}
+{% set max_mod_query %}
+
+SELECT
+    MAX(modified_timestamp) modified_timestamp
+FROM
+    {{ this }}
+
+    {% endset %}
+    {% set max_mod = run_query(max_mod_query) [0] [0] %}
+    {% if not max_mod or max_mod == 'None' %}
+        {% set max_mod = '2099-01-01' %}
+    {% endif %}
+{% endif %}
+
+--get the distinct blockchains & block dates that we are processing
+{% set dates_query %}
+CREATE
+OR REPLACE temporary TABLE silver.ez_dex_metrics__intermediate_tmp AS
+SELECT
+    DISTINCT blockchain,
+    block_timestamp :: DATE AS block_date
+FROM
+    {{ ref('defi__ez_dex_swaps') }}
+WHERE
+    block_timestamp :: DATE < SYSDATE() :: DATE
+    AND block_timestamp :: DATE >= '2025-07-01'
+
+{% if is_incremental() %}
+AND modified_timestamp >= '{{ max_mod }}'
+AND block_timestamp :: DATE >= '2025-07-01'
+{% endif %}
+
+{% endset %}
+{% do run_query(dates_query) %}
+--create a dynamic where clause with literal block dates
+{% set date_query %}
+SELECT
+    DISTINCT block_date
+FROM
+    silver.ez_dex_metrics__intermediate_tmp {% endset %}
+    {% set date_results = run_query(date_query) %}
+    {% set date_filter %}
+    A.block_timestamp :: DATE IN ({% if date_results.rows | length > 0 %}
+        {% for date in date_results %}
+            '{{ date[0] }}' {% if not loop.last %},
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        '2099-01-01'
+    {% endif %}) {% endset %}
+{% endif %}
+
+WITH swaps AS (
+    SELECT
+        A.blockchain,
+        A.block_timestamp :: DATE AS block_date,
+        COUNT(1) AS swap_count,
+        COUNT(
+            DISTINCT trader
+        ) AS distinct_swapper_count,
+        SUM(
+            CASE
+                WHEN token_in_is_verified
+                AND amount_in_usd IS NOT NULL THEN amount_in_usd
+                WHEN token_out_is_verified
+                AND amount_out_usd IS NOT NULL THEN amount_out_usd
+                ELSE 0
+            END
+        ) AS gross_dex_volume_usd
+    FROM
+        {{ ref('defi__ez_dex_swaps') }} A
+        JOIN silver.ez_dex_metrics__intermediate_tmp b
+        ON A.blockchain = b.blockchain
+        AND A.block_timestamp :: DATE = b.block_date
+    WHERE
+        {{ date_filter }}
+    GROUP BY
+        A.blockchain,
+        A.block_timestamp :: DATE
+)
+SELECT
+    A.blockchain,
+    A.block_date,
+    A.swap_count,
+    A.distinct_swapper_count,
+    A.gross_dex_volume_usd,
+    {{ dbt_utils.generate_surrogate_key(['a.blockchain',' A.block_date']) }} AS ez_dex_metrics_daily_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp
+FROM
+    swaps A

--- a/models/gold/stats/stats__ez_dex_metrics_daily.yml
+++ b/models/gold/stats/stats__ez_dex_metrics_daily.yml
@@ -1,0 +1,39 @@
+version: 2
+models:
+  - name: stats__ez_dex_metrics_daily
+    description: "An aggregated daily view of cross-chain dex metrics, including volume, distinct addresses and unique transactions grouped by blockchain."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_DATE
+            - BLOCKCHAIN
+
+    columns:
+      - name: BLOCKCHAIN 
+        description: '{{ doc("blockchain_column") }}'
+      - name: BLOCK_DATE
+        description: '{{ doc("block_date") }}'
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: swap_count
+        description: 'The number of swaps that occurred on BLOCKCHAIN on BLOCK_DATE'
+        tests:
+          - not_null
+      - name: distinct_swapper_count
+        description: '# unique addresses swapping tokens on BLOCKCHAIN from any dex protocol'
+        tests:
+          - not_null
+      - name: gross_dex_volume_usd
+        description:  
+        description: 'USD value of all swaps of verified tokens on BLOCKCHAIN on any dex protocol'
+        # tests:
+        #   - not_null 
+      - name: EZ_DEX_METRICS_DAILY_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/stats/stats__ez_dex_protocol_metrics_daily.sql
+++ b/models/gold/stats/stats__ez_dex_protocol_metrics_daily.sql
@@ -1,0 +1,107 @@
+-- depends_on: {{ ref('defi__ez_dex_swaps') }}
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'merge',
+    merge_exclude_columns = ["inserted_timestamp"],
+    unique_key = ['blockchain','block_date','protocol'],
+    cluster_by = ['blockchain','block_date','protocol'],
+    tags = ['metrics_daily']
+) }}
+
+{% if execute %}
+
+{% if is_incremental() %}
+{% set max_mod_query %}
+
+SELECT
+    MAX(modified_timestamp) modified_timestamp
+FROM
+    {{ this }}
+
+    {% endset %}
+    {% set max_mod = run_query(max_mod_query) [0] [0] %}
+    {% if not max_mod or max_mod == 'None' %}
+        {% set max_mod = '2099-01-01' %}
+    {% endif %}
+{% endif %}
+
+--get the distinct blockchains & block dates that we are processing
+{% set dates_query %}
+CREATE
+OR REPLACE temporary TABLE silver.ez_dex_metrics__intermediate_tmp AS
+SELECT
+    DISTINCT blockchain,
+    block_timestamp :: DATE AS block_date
+FROM
+    {{ ref('defi__ez_dex_swaps') }}
+WHERE
+    block_timestamp :: DATE < SYSDATE() :: DATE
+    AND block_timestamp :: DATE >= '2025-07-01'
+
+{% if is_incremental() %}
+AND modified_timestamp >= '{{ max_mod }}'
+AND block_timestamp :: DATE >= '2025-07-01'
+{% endif %}
+
+{% endset %}
+{% do run_query(dates_query) %}
+--create a dynamic where clause with literal block dates
+{% set date_query %}
+SELECT
+    DISTINCT block_date
+FROM
+    silver.ez_dex_metrics__intermediate_tmp {% endset %}
+    {% set date_results = run_query(date_query) %}
+    {% set date_filter %}
+    A.block_timestamp :: DATE IN ({% if date_results.rows | length > 0 %}
+        {% for date in date_results %}
+            '{{ date[0] }}' {% if not loop.last %},
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        '2099-01-01'
+    {% endif %}) {% endset %}
+{% endif %}
+
+WITH swaps AS (
+    SELECT
+        A.blockchain,
+        A.platform AS protocol,
+        A.block_timestamp :: DATE AS block_date,
+        COUNT(1) AS swap_count,
+        COUNT(
+            DISTINCT trader
+        ) AS distinct_swapper_count,
+        SUM(
+            CASE
+                WHEN token_in_is_verified
+                AND amount_in_usd IS NOT NULL THEN amount_in_usd
+                WHEN token_out_is_verified
+                AND amount_out_usd IS NOT NULL THEN amount_out_usd
+                ELSE 0
+            END
+        ) AS gross_dex_volume_usd
+    FROM
+        {{ ref('defi__ez_dex_swaps') }} A
+        JOIN silver.ez_dex_metrics__intermediate_tmp b
+        ON A.blockchain = b.blockchain
+        AND A.block_timestamp :: DATE = b.block_date
+    WHERE
+        {{ date_filter }}
+    GROUP BY
+        A.blockchain,
+        A.platform,
+        A.block_timestamp :: DATE
+)
+SELECT
+    A.blockchain,
+    A.protocol,
+    A.block_date,
+    A.swap_count,
+    A.distinct_swapper_count,
+    A.gross_dex_volume_usd,
+    {{ dbt_utils.generate_surrogate_key(['a.blockchain',' A.block_date','A.protocol']) }} AS ez_dex_protocol_metrics_daily_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp
+FROM
+    swaps A

--- a/models/gold/stats/stats__ez_dex_protocol_metrics_daily.yml
+++ b/models/gold/stats/stats__ez_dex_protocol_metrics_daily.yml
@@ -1,0 +1,42 @@
+version: 2
+models:
+  - name: stats__ez_dex_protocol_metrics_daily
+    description: "An aggregated daily view of cross-chain dex metrics, including volume, distinct addresses and unique transactions grouped by blockchain and dex protocol."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_DATE
+            - BLOCKCHAIN
+            - PROTOCOL
+
+    columns:
+      - name: BLOCKCHAIN 
+        description: '{{ doc("blockchain_column") }}'
+      - name: PROTOCOL 
+        description: '{{ doc("cross_chain_swap_platform") }}'
+      - name: BLOCK_DATE
+        description: '{{ doc("block_date") }}'
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: swap_count
+        description: 'The number of swaps that occurred on BLOCKCHAIN on BLOCK_DATE'
+        tests:
+          - not_null
+      - name: distinct_swapper_count
+        description: '# unique addresses swapping tokens on BLOCKCHAIN from any dex protocol'
+        tests:
+          - not_null
+      - name: gross_dex_volume_usd
+        description:  
+        description: 'USD value of all swaps of verified tokens on BLOCKCHAIN on any dex protocol'
+        # tests:
+        #   - not_null 
+      - name: EZ_DEX_PROTOCOL_METRICS_DAILY_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/stats/stats__ez_dex_token_metrics_daily.sql
+++ b/models/gold/stats/stats__ez_dex_token_metrics_daily.sql
@@ -1,0 +1,203 @@
+-- depends_on: {{ ref('defi__ez_dex_swaps') }}
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'merge',
+    merge_exclude_columns = ["inserted_timestamp"],
+    unique_key = ['blockchain','block_date','token_address'],
+    cluster_by = ['blockchain','block_date'],
+    tags = ['metrics_daily']
+) }}
+
+{% if execute %}
+
+{% if is_incremental() %}
+{% set max_mod_query %}
+
+SELECT
+    MAX(modified_timestamp) modified_timestamp
+FROM
+    {{ this }}
+
+    {% endset %}
+    {% set max_mod = run_query(max_mod_query) [0] [0] %}
+    {% if not max_mod or max_mod == 'None' %}
+        {% set max_mod = '2099-01-01' %}
+    {% endif %}
+{% endif %}
+
+--get the distinct blockchains & block dates that we are processing
+{% set dates_query %}
+CREATE
+OR REPLACE temporary TABLE silver.ez_dex_metrics__intermediate_tmp AS
+SELECT
+    DISTINCT blockchain,
+    block_timestamp :: DATE AS block_date
+FROM
+    {{ ref('defi__ez_dex_swaps') }}
+WHERE
+    block_timestamp :: DATE < SYSDATE() :: DATE
+    AND block_timestamp :: DATE >= '2025-07-01'
+
+{% if is_incremental() %}
+AND modified_timestamp >= '{{ max_mod }}'
+AND block_timestamp :: DATE >= '2025-07-01'
+{% endif %}
+
+{% endset %}
+{% do run_query(dates_query) %}
+--create a dynamic where clause with literal block dates
+{% set date_query %}
+SELECT
+    DISTINCT block_date
+FROM
+    silver.ez_dex_metrics__intermediate_tmp {% endset %}
+    {% set date_results = run_query(date_query) %}
+    {% set date_filter %}
+    A.block_timestamp :: DATE IN ({% if date_results.rows | length > 0 %}
+        {% for date in date_results %}
+            '{{ date[0] }}' {% if not loop.last %},
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        '2099-01-01'
+    {% endif %}) {% endset %}
+{% endif %}
+
+WITH swaps_in AS (
+    SELECT
+        A.blockchain,
+        A.token_in AS token_address,
+        MAX(
+            A.symbol_in
+        ) AS symbol,
+        A.block_timestamp :: DATE AS block_date,
+        COUNT(1) AS buy_swap_count,
+        ARRAY_AGG(
+            DISTINCT trader
+        ) AS swappers,
+        SUM(amount_in) AS buy_volume,
+        SUM(amount_in_usd) AS buy_usd_volume
+    FROM
+        {{ ref('defi__ez_dex_swaps') }} A
+        JOIN silver.ez_dex_metrics__intermediate_tmp b
+        ON A.blockchain = b.blockchain
+        AND A.block_timestamp :: DATE = b.block_date
+    WHERE
+        token_in_is_verified
+        AND {{ date_filter }}
+    GROUP BY
+        A.blockchain,
+        A.token_in,
+        A.block_timestamp :: DATE
+),
+swaps_out AS (
+    SELECT
+        A.blockchain,
+        A.token_out AS token_address,
+        MAX(
+            A.symbol_out
+        ) AS symbol,
+        A.block_timestamp :: DATE AS block_date,
+        COUNT(1) AS sell_swap_count,
+        ARRAY_AGG(
+            DISTINCT trader
+        ) AS swappers,
+        SUM(amount_out) AS sell_volume,
+        SUM(amount_out_usd) AS sell_usd_volume
+    FROM
+        {{ ref('defi__ez_dex_swaps') }} A
+        JOIN silver.ez_dex_metrics__intermediate_tmp b
+        ON A.blockchain = b.blockchain
+        AND A.block_timestamp :: DATE = b.block_date
+    WHERE
+        token_out_is_verified
+        AND {{ date_filter }}
+    GROUP BY
+        A.blockchain,
+        A.token_out,
+        A.block_timestamp :: DATE
+),
+base AS (
+    SELECT
+        DISTINCT blockchain,
+        block_date,
+        token_address
+    FROM
+        swaps_in
+    UNION
+    SELECT
+        DISTINCT blockchain,
+        block_date,
+        token_address
+    FROM
+        swaps_out
+),
+swappers AS (
+    SELECT
+        A.blockchain,
+        A.token_address,
+        A.block_date,
+        ARRAY_SIZE(array_union_agg(swappers)) AS token_swappers
+    FROM
+        (
+            SELECT
+                blockchain,
+                token_address,
+                block_date,
+                swappers
+            FROM
+                swaps_in
+            UNION ALL
+            SELECT
+                blockchain,
+                token_address,
+                block_date,
+                swappers
+            FROM
+                swaps_out
+        ) A
+    GROUP BY
+        A.blockchain,
+        A.token_address,
+        A.block_date
+)
+SELECT
+    A.blockchain,
+    A.token_address,
+    GREATEST(
+        si.symbol,
+        so.symbol
+    ) AS symbol,
+    A.block_date,
+    si.buy_swap_count,
+    si.buy_volume,
+    si.buy_usd_volume,
+    so.sell_swap_count,
+    sers.token_swappers,
+    so.sell_volume,
+    so.sell_usd_volume,
+    COALESCE(
+        si.buy_volume,
+        0
+    ) - COALESCE(
+        so.sell_volume,
+        0
+    ) AS net_purchased,
+    ROUND(COALESCE(si.buy_usd_volume, 0) - COALESCE(so.sell_usd_volume, 0), 2) AS net_purchased_usd,
+    {{ dbt_utils.generate_surrogate_key(['a.blockchain',' A.block_date','A.token_address']) }} AS ez_dex_token_metrics_daily_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp
+FROM
+    base A
+    LEFT JOIN swappers sers
+    ON A.blockchain = sers.blockchain
+    AND A.token_address = sers.token_address
+    AND A.block_date = sers.block_date
+    LEFT JOIN swaps_in si
+    ON A.blockchain = si.blockchain
+    AND A.token_address = si.token_address
+    AND A.block_date = si.block_date
+    LEFT JOIN swaps_out so
+    ON A.blockchain = so.blockchain
+    AND A.token_address = so.token_address
+    AND A.block_date = so.block_date

--- a/models/gold/stats/stats__ez_dex_token_metrics_daily.yml
+++ b/models/gold/stats/stats__ez_dex_token_metrics_daily.yml
@@ -1,0 +1,58 @@
+version: 2
+models:
+  - name: stats__ez_dex_token_metrics_daily
+    description: "An aggregated daily view of cross-chain dex metrics, including volume, distinct addresses and unique transactions grouped by blockchain and token. This only includes verified tokens."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_DATE
+            - BLOCKCHAIN
+            - TOKEN_ADDRESS
+
+    columns:
+      - name: BLOCKCHAIN 
+        description: '{{ doc("blockchain_column") }}'
+      - name: TOKEN_ADDRESS 
+        description: '{{ doc("prices_token_address") }}'
+      - name: SYMBOL 
+        description: '{{ doc("prices_symbol") }}'
+      - name: BLOCK_DATE
+        description: '{{ doc("block_date") }}'
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+      - name: buy_swap_count
+        description: 'The number of buy swaps that occurred on BLOCKCHAIN on BLOCK_DATE'
+        # tests:
+        #   - not_null
+      - name: buy_volume
+        description: 'The buy volume of swaps that occurred on BLOCKCHAIN on BLOCK_DATE in the token specified by TOKEN_ADDRESS'
+        # tests:
+        #   - not_null
+      - name: buy_usd_volume
+        description:  
+        description: 'USD value of all buy swaps of the token on BLOCKCHAIN on any dex protocol'
+        # tests:
+        #   - not_null
+      - name: sell_swap_count
+        description: 'The number of sell swaps that occurred on BLOCKCHAIN on BLOCK_DATE'
+        # tests:
+        #   - not_null
+      - name: sell_volume
+        description: 'The sell volume of swaps that occurred on BLOCKCHAIN on BLOCK_DATE in the token specified by TOKEN_ADDRESS'
+        # tests:
+        #   - not_null
+      - name: sell_usd_volume
+        description: 'USD value of all sell swaps of the token on BLOCKCHAIN on any dex protocol'
+      - name: net_purchased
+        description: 'buy_volume - sell_volume'
+      - name: net_purchased_usd
+        description: 'buy_usd_volume - sell_usd_volume'
+      - name: EZ_DEX_TOKEN_METRICS_DAILY_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/silver/defi/silver__complete_dex_swaps.sql
+++ b/models/silver/defi/silver__complete_dex_swaps.sql
@@ -3,7 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = ['_unique_key'],
     cluster_by = ['block_timestamp::DATE','blockchain','platform'],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_hash, contract_address, trader, token_in, token_out, symbol_in, symbol_out), SUBSTRING(trader, token_in, token_out, symbol_in, symbol_out)",
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_hash, contract_address, trader, token_in, token_out, symbol_in, symbol_out, _unique_key), SUBSTRING(trader, token_in, token_out, symbol_in, symbol_out)",
     tags = ['hourly']
 ) }}
 
@@ -27,7 +27,13 @@ WITH ethereum AS (
         amount_out_unadj AS amount_out_raw,
         amount_out,
         amount_out_usd,
-        CONCAT(tx_hash :: STRING, '-', event_index :: STRING) AS _log_id,
+        token_in_is_verified,
+        token_out_is_verified,
+        CONCAT(
+            tx_hash :: STRING,
+            '-',
+            event_index :: STRING
+        ) AS _log_id,
         modified_timestamp AS _inserted_timestamp,
         {{ dbt_utils.generate_surrogate_key(['ez_dex_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
         {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
@@ -66,7 +72,13 @@ optimism AS (
         amount_out_unadj AS amount_out_raw,
         amount_out,
         amount_out_usd,
-        CONCAT(tx_hash :: STRING, '-', event_index :: STRING) AS _log_id,
+        token_in_is_verified,
+        token_out_is_verified,
+        CONCAT(
+            tx_hash :: STRING,
+            '-',
+            event_index :: STRING
+        ) AS _log_id,
         modified_timestamp AS _inserted_timestamp,
         {{ dbt_utils.generate_surrogate_key(['ez_dex_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
         {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
@@ -105,7 +117,13 @@ avalanche AS (
         amount_out_unadj AS amount_out_raw,
         amount_out,
         amount_out_usd,
-        CONCAT(tx_hash :: STRING, '-', event_index :: STRING) AS _log_id,
+        token_in_is_verified,
+        token_out_is_verified,
+        CONCAT(
+            tx_hash :: STRING,
+            '-',
+            event_index :: STRING
+        ) AS _log_id,
         modified_timestamp AS _inserted_timestamp,
         {{ dbt_utils.generate_surrogate_key(['ez_dex_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
         {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
@@ -144,7 +162,13 @@ polygon AS (
         amount_out_unadj AS amount_out_raw,
         amount_out,
         amount_out_usd,
-        CONCAT(tx_hash :: STRING, '-', event_index :: STRING) AS _log_id,
+        token_in_is_verified,
+        token_out_is_verified,
+        CONCAT(
+            tx_hash :: STRING,
+            '-',
+            event_index :: STRING
+        ) AS _log_id,
         modified_timestamp AS _inserted_timestamp,
         {{ dbt_utils.generate_surrogate_key(['ez_dex_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
         {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
@@ -183,7 +207,13 @@ bsc AS (
         amount_out_unadj AS amount_out_raw,
         amount_out,
         amount_out_usd,
-        CONCAT(tx_hash :: STRING, '-', event_index :: STRING) AS _log_id,
+        token_in_is_verified,
+        token_out_is_verified,
+        CONCAT(
+            tx_hash :: STRING,
+            '-',
+            event_index :: STRING
+        ) AS _log_id,
         modified_timestamp AS _inserted_timestamp,
         {{ dbt_utils.generate_surrogate_key(['ez_dex_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
         {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
@@ -222,7 +252,13 @@ arbitrum AS (
         amount_out_unadj AS amount_out_raw,
         amount_out,
         amount_out_usd,
-        CONCAT(tx_hash :: STRING, '-', event_index :: STRING) AS _log_id,
+        token_in_is_verified,
+        token_out_is_verified,
+        CONCAT(
+            tx_hash :: STRING,
+            '-',
+            event_index :: STRING
+        ) AS _log_id,
         modified_timestamp AS _inserted_timestamp,
         {{ dbt_utils.generate_surrogate_key(['ez_dex_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
         {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
@@ -261,7 +297,13 @@ base AS (
         amount_out_unadj AS amount_out_raw,
         amount_out,
         amount_out_usd,
-        CONCAT(tx_hash :: STRING, '-', event_index :: STRING) AS _log_id,
+        token_in_is_verified,
+        token_out_is_verified,
+        CONCAT(
+            tx_hash :: STRING,
+            '-',
+            event_index :: STRING
+        ) AS _log_id,
         modified_timestamp AS _inserted_timestamp,
         {{ dbt_utils.generate_surrogate_key(['ez_dex_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
         {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
@@ -281,9 +323,9 @@ WHERE
     )
 {% endif %}
 ),
-blast AS (
+core AS (
     SELECT
-        'blast' AS blockchain,
+        'core' AS blockchain,
         platform,
         block_number,
         block_timestamp,
@@ -300,17 +342,23 @@ blast AS (
         amount_out_unadj AS amount_out_raw,
         amount_out,
         amount_out_usd,
-        CONCAT(tx_hash :: STRING, '-', event_index :: STRING) AS _log_id,
+        token_in_is_verified,
+        token_out_is_verified,
+        CONCAT(
+            tx_hash :: STRING,
+            '-',
+            event_index :: STRING
+        ) AS _log_id,
         modified_timestamp AS _inserted_timestamp,
         {{ dbt_utils.generate_surrogate_key(['ez_dex_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
         {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
     FROM
         {{ source(
-            'blast_defi',
+            'core_defi',
             'ez_dex_swaps'
         ) }}
 
-{% if is_incremental() and 'blast' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'core' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
@@ -320,6 +368,52 @@ WHERE
     )
 {% endif %}
 ),
+{# ink AS (
+SELECT
+    'ink' AS blockchain,
+    platform,
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    origin_from_address AS trader,
+    token_in,
+    symbol_in,
+    amount_in_unadj AS amount_in_raw,
+    amount_in,
+    amount_in_usd,
+    token_out,
+    symbol_out,
+    amount_out_unadj AS amount_out_raw,
+    amount_out,
+    amount_out_usd,
+    token_in_is_verified,
+    token_out_is_verified,
+    CONCAT(
+        tx_hash :: STRING,
+        '-',
+        event_index :: STRING
+    ) AS _log_id,
+    modified_timestamp AS _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['ez_dex_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
+    {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
+FROM
+    {{ source(
+        'ink_defi',
+        'ez_dex_swaps'
+    ) }}
+
+{% if is_incremental() and 'ink' not in var('HEAL_MODELS') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "6 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
+),
+#}
 gnosis AS (
     SELECT
         'gnosis' AS blockchain,
@@ -339,7 +433,13 @@ gnosis AS (
         amount_out_unadj AS amount_out_raw,
         amount_out,
         amount_out_usd,
-        CONCAT(tx_hash :: STRING, '-', event_index :: STRING) AS _log_id,
+        token_in_is_verified,
+        token_out_is_verified,
+        CONCAT(
+            tx_hash :: STRING,
+            '-',
+            event_index :: STRING
+        ) AS _log_id,
         modified_timestamp AS _inserted_timestamp,
         {{ dbt_utils.generate_surrogate_key(['ez_dex_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
         {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
@@ -359,55 +459,57 @@ WHERE
     )
 {% endif %}
 ),
-osmosis AS (
-    SELECT
-        'osmosis' AS blockchain,
-        'osmosis' platform,
-        s.block_id AS block_number,
-        s.block_timestamp,
-        s.tx_id AS tx_hash,
-        pool_address AS contract_address,
-        trader AS trader,
-        from_currency AS token_in,
-        NULL AS symbol_in,
-        from_amount AS amount_in_raw,
-        CASE
-            WHEN s.from_decimal IS NOT NULL THEN from_amount / power(
-                10,
-                s.from_decimal
-            )
-        END AS amount_in,
-        NULL AS amount_in_usd,
-        to_currency AS token_out,
-        NULL AS symbol_out,
-        to_amount AS amount_out_raw,
-        CASE
-            WHEN s.to_decimal IS NOT NULL THEN to_amount / power(
-                10,
-                s.to_decimal
-            )
-        END AS amount_out,
-        NULL AS amount_out_usd,
-        CONCAT(
-            s.tx_id,
-            '-',
-            s._BODY_INDEX
-        ) AS _log_id,
-        s.modified_timestamp AS _inserted_timestamp,
-        {{ dbt_utils.generate_surrogate_key(['fact_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
-        {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
-    FROM
-        {{ source(
-            'osmosis_defi',
-            'fact_swaps'
-        ) }}
-        s
-        LEFT JOIN {{ source(
-            'osmosis_defi',
-            'dim_liquidity_pools'
-        ) }}
-        p
-        ON s.pool_id = p.pool_id
+{# osmosis AS (
+SELECT
+    'osmosis' AS blockchain,
+    'osmosis' platform,
+    s.block_id AS block_number,
+    s.block_timestamp,
+    s.tx_id AS tx_hash,
+    pool_address AS contract_address,
+    trader AS trader,
+    from_currency AS token_in,
+    NULL AS symbol_in,
+    from_amount AS amount_in_raw,
+    CASE
+        WHEN s.from_decimal IS NOT NULL THEN from_amount / power(
+            10,
+            s.from_decimal
+        )
+    END AS amount_in,
+    NULL AS amount_in_usd,
+    to_currency AS token_out,
+    NULL AS symbol_out,
+    to_amount AS amount_out_raw,
+    CASE
+        WHEN s.to_decimal IS NOT NULL THEN to_amount / power(
+            10,
+            s.to_decimal
+        )
+    END AS amount_out,
+    NULL AS amount_out_usd,
+    FALSE AS token_in_is_verified,
+    FALSE AS token_out_is_verified,
+    CONCAT(
+        s.tx_id,
+        '-',
+        s._BODY_INDEX
+    ) AS _log_id,
+    s.modified_timestamp AS _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(['fact_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
+    {{ dbt_utils.generate_surrogate_key(['blockchain','block_number','platform']) }} AS _unique_key
+FROM
+    {{ source(
+        'osmosis_defi',
+        'fact_swaps'
+    ) }}
+    s
+    LEFT JOIN {{ source(
+        'osmosis_defi',
+        'dim_liquidity_pools'
+    ) }}
+    p
+    ON s.pool_id = p.pool_id
 
 {% if is_incremental() and 'osmosis' not in var('HEAL_MODELS') %}
 WHERE
@@ -419,6 +521,7 @@ WHERE
     )
 {% endif %}
 ),
+#}
 solana AS (
     SELECT
         'solana' AS blockchain,
@@ -429,35 +532,35 @@ solana AS (
         program_id AS contract_address,
         swapper AS trader,
         swap_from_mint AS token_in,
-        NULL AS symbol_in,
-        swap_from_amount AS amount_in_raw,
-        amount_in_raw AS amount_in,
-        NULL AS amount_in_usd,
+        swap_from_symbol AS symbol_in,
+        NULL AS amount_in_raw,
+        swap_from_amount AS amount_in,
+        swap_from_amount_usd AS amount_in_usd,
         swap_to_mint AS token_out,
-        NULL AS symbol_out,
-        swap_to_amount AS amount_out_raw,
-        amount_out_raw AS amount_out,
-        NULL AS amount_out_usd,
-        _log_id,
+        swap_to_symbol AS symbol_out,
+        NULL AS amount_out_raw,
+        swap_to_amount AS amount_out,
+        swap_to_amount_usd AS amount_out_usd,
+        swap_from_is_verified AS token_in_is_verified,
+        swap_to_is_verified AS token_out_is_verified,
+        ez_swaps_id AS _log_id,
         modified_timestamp AS _inserted_timestamp,
-        {{ dbt_utils.generate_surrogate_key(['fact_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
-        {{ dbt_utils.generate_surrogate_key(['fact_swaps_id','blockchain']) }} AS _unique_key
+        {{ dbt_utils.generate_surrogate_key(['ez_swaps_id','blockchain']) }} AS complete_dex_swaps_id,
+        {{ dbt_utils.generate_surrogate_key(['ez_swaps_id','blockchain']) }} AS _unique_key
     FROM
         {{ source(
             'solana_defi',
-            'fact_swaps'
+            'ez_dex_swaps'
         ) }}
-    WHERE
-        succeeded
-        AND _log_id IS NOT NULL
 
 {% if is_incremental() and 'solana' not in var('HEAL_MODELS') %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "24 hours") }}'
-    FROM
-        {{ this }}
-)
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "24 hours") }}'
+        FROM
+            {{ this }}
+    )
 {% endif %}
 ),
 near AS (
@@ -473,12 +576,14 @@ near AS (
         symbol_in,
         amount_in_raw,
         amount_in,
-        NULL AS amount_in_usd,
+        amount_in_usd AS amount_in_usd,
         LOWER(token_out_contract) AS token_out,
         symbol_out,
         amount_out_raw,
         amount_out,
-        NULL AS amount_out_usd,
+        amount_out_usd AS amount_out_usd,
+        token_in_is_verified,
+        token_out_is_verified,
         ez_dex_swaps_id AS _log_id,
         modified_timestamp AS _inserted_timestamp,
         {{ dbt_utils.generate_surrogate_key(['_log_id','blockchain']) }} AS complete_dex_swaps_id,
@@ -490,6 +595,47 @@ near AS (
         ) }}
 
 {% if is_incremental() and 'near' not in var('HEAL_MODELS') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "24 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
+),
+aptos AS (
+    SELECT
+        'aptos' AS blockchain,
+        platform,
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_address AS contract_address,
+        swapper,
+        token_in,
+        symbol_in,
+        amount_in_unadj AS amount_in_raw,
+        amount_in,
+        amount_in_usd,
+        token_out,
+        symbol_out,
+        amount_out_unadj AS amount_out_raw,
+        amount_out,
+        amount_out_usd,
+        token_in_is_verified,
+        token_out_is_verified,
+        ez_dex_swaps_id AS _log_id,
+        modified_timestamp AS _inserted_timestamp,
+        {{ dbt_utils.generate_surrogate_key(['_log_id','blockchain']) }} AS complete_dex_swaps_id,
+        {{ dbt_utils.generate_surrogate_key(['_log_id','blockchain']) }} AS _unique_key
+    FROM
+        {{ source(
+            'aptos_defi',
+            'ez_dex_swaps'
+        ) }}
+
+{% if is_incremental() and 'aptos' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
@@ -538,18 +684,23 @@ all_chains_dex AS (
     SELECT
         *
     FROM
-        blast
+        core {# UNION ALL
+    SELECT
+        *
+    FROM
+        ink #}
     UNION ALL
     SELECT
         *
     FROM
         gnosis
     UNION ALL
-    SELECT
+        {# SELECT
         *
     FROM
         osmosis
     UNION ALL
+        #}
     SELECT
         *
     FROM
@@ -559,19 +710,11 @@ all_chains_dex AS (
         *
     FROM
         near
-),
-prices AS (
+    UNION ALL
     SELECT
-        HOUR,
-        token_address,
-        symbol,
-        decimals,
-        price,
-        blockchain
+        *
     FROM
-        {{ ref('price__ez_prices_hourly') }}
-    WHERE
-        NOT is_native
+        aptos
 )
 SELECT
     d.blockchain,
@@ -582,53 +725,17 @@ SELECT
     d.contract_address,
     d.trader,
     d.token_in,
-    COALESCE(
-        d.symbol_in,
-        p_in.symbol
-    ) AS symbol_in,
+    d.symbol_in,
+    token_in_is_verified,
     d.amount_in_raw,
     d.amount_in,
-    CASE
-        WHEN d.blockchain IN (
-            'ethereum',
-            'optimism',
-            'base',
-            'blast',
-            'arbitrum',
-            'polygon',
-            'bsc',
-            'avalanche',
-            'gnosis'
-        ) THEN d.amount_in_usd
-        ELSE ROUND(
-            p_in.price * d.amount_in,
-            2
-        )
-    END AS amount_in_usd,
+    d.amount_in_usd,
     d.token_out,
-    COALESCE(
-        d.symbol_out,
-        p_out.symbol
-    ) AS symbol_out,
+    d.symbol_out,
+    token_out_is_verified,
     d.amount_out_raw,
     d.amount_out,
-    CASE
-        WHEN d.blockchain IN (
-            'ethereum',
-            'optimism',
-            'base',
-            'blast',
-            'arbitrum',
-            'polygon',
-            'bsc',
-            'avalanche',
-            'gnosis'
-        ) THEN d.amount_out_usd
-        ELSE ROUND(
-            p_out.price * d.amount_out,
-            2
-        )
-    END AS amount_out_usd,
+    d.amount_out_usd,
     d._log_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,
@@ -637,25 +744,3 @@ SELECT
     d._unique_key
 FROM
     all_chains_dex d
-    LEFT JOIN prices p_in
-    ON REPLACE(
-        d.blockchain,
-        'osmosis',
-        'cosmos'
-    ) = p_in.blockchain
-    AND d.token_in = p_in.token_address
-    AND DATE_TRUNC(
-        'hour',
-        d.block_timestamp
-    ) = p_in.hour
-    LEFT JOIN prices p_out
-    ON REPLACE(
-        d.blockchain,
-        'osmosis',
-        'cosmos'
-    ) = p_out.blockchain
-    AND d.token_out = p_out.token_address
-    AND DATE_TRUNC(
-        'hour',
-        d.block_timestamp
-    ) = p_out.hour

--- a/models/silver/prices/onchain/silver__onchain_osmosis_prices.yml
+++ b/models/silver/prices/onchain/silver__onchain_osmosis_prices.yml
@@ -16,9 +16,9 @@ models:
         description: opening hour of price data
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
+          # - dbt_expectations.expect_row_values_to_have_recent_data:
+          #     datepart: day
+          #     interval: 1
       - name: OPEN
         description: open price of asset for hour
         tests:

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -53,6 +53,7 @@ sources:
     schema: defi
     tables:
       - name: ez_bridge_activity
+      - name: ez_dex_swaps
 
   - name: aptos_observ
     database: aptos
@@ -521,6 +522,7 @@ sources:
     schema: defi
     tables:
       - name: ez_bridge_activity
+      - name: ez_dex_swaps
 
   - name: core_silver
     database: core
@@ -887,6 +889,7 @@ sources:
     schema: defi
     tables:
       - name: ez_bridge_activity
+      # - name: ez_dex_swaps
 
   - name: ink_silver
     database: ink
@@ -1279,6 +1282,7 @@ sources:
     tables:
       - name: fact_swaps
       - name: ez_bridge_activity
+      - name: ez_dex_swaps
 
   - name: solana_observ
     database: solana


### PR DESCRIPTION
1. Remove recency test on osmosis prices (future pr to fully deprecate)
2. add core and aptos / remove osmosis and blast from complete dex swaps
3. add is_verified to defi.ez_dex_swaps
4. create three dex level aggregates models (chain, chain/protocol, chain/token)