### PR TITLE
Dedupe silver.tags_thor_liqudity_provider

### DIFF
--- a/models/silver/tags/Thorchain/silver__tags_thor_liquidity_provider.sql
+++ b/models/silver/tags/Thorchain/silver__tags_thor_liquidity_provider.sql
@@ -154,3 +154,9 @@ SELECT
     '{{ invocation_id }}' AS _invocation_id
 FROM
     final_table A
+QUALIFY(
+    ROW_NUMBER() over (
+        PARTITION BY address 
+        ORDER BY block_id DESC
+    ) = 1
+)


### PR DESCRIPTION
Address `thor1ef...qdz` was duplicated across block IDs `21948218` and `21948080`. Added a qualify statement to select the address with the highest block ID.

